### PR TITLE
월별 리포트 및 통계 관련 비즈니스 로직에 예외 처리 추가

### DIFF
--- a/src/main/java/org/example/bankramenserver/domain/report/presentation/MonthlyReportController.java
+++ b/src/main/java/org/example/bankramenserver/domain/report/presentation/MonthlyReportController.java
@@ -7,12 +7,9 @@ import org.example.bankramenserver.domain.report.service.GetMonthlyAmountSummary
 import org.example.bankramenserver.domain.report.service.GetMonthlyCategoryExpenseListService;
 import org.example.bankramenserver.global.document.MonthlyReportApiDocument;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,22 +20,20 @@ public class MonthlyReportController implements MonthlyReportApiDocument {
     private final GetMonthlyCategoryExpenseListService getMonthlyCategoryExpenseListService;
 
     @Override
-    @GetMapping("/summary/{userId}")
+    @GetMapping("/summary")
     public MonthlyAmountSummaryResponse getMonthlyAmountSummary(
-            @PathVariable UUID userId,
             @RequestParam int year,
             @RequestParam int month
     ) {
-        return getMonthlyAmountSummaryService.execute(userId, year, month);
+        return getMonthlyAmountSummaryService.execute(year, month);
     }
 
     @Override
-    @GetMapping("/categories/{userId}")
+    @GetMapping("/categories")
     public MonthlyCategoryExpenseListResponse getMonthlyCategoryExpenses(
-            @PathVariable UUID userId,
             @RequestParam int year,
             @RequestParam int month
     ) {
-        return getMonthlyCategoryExpenseListService.execute(userId, year, month);
+        return getMonthlyCategoryExpenseListService.execute(year, month);
     }
 }

--- a/src/main/java/org/example/bankramenserver/domain/report/service/GetMonthlyAmountSummaryService.java
+++ b/src/main/java/org/example/bankramenserver/domain/report/service/GetMonthlyAmountSummaryService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.bankramenserver.domain.report.domain.repository.AmountSummaryRow;
 import org.example.bankramenserver.domain.report.domain.repository.MonthlyReportRepository;
 import org.example.bankramenserver.domain.report.presentation.dto.MonthlyAmountSummaryResponse;
-import org.example.bankramenserver.domain.user.domain.repository.UserRepository;
+import org.example.bankramenserver.domain.user.facade.UserFacade;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,17 +17,18 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class GetMonthlyAmountSummaryService {
 
-    private final UserRepository userRepository;
+    private final UserFacade userFacade;
     private final MonthlyReportRepository monthlyReportRepository;
 
     @Transactional(readOnly = true)
-    public MonthlyAmountSummaryResponse execute(UUID userId, int year, int month) {
-        validateUserExists(userId);
+    public MonthlyAmountSummaryResponse execute(int year, int month) {
+        UUID currentUserId = userFacade.getCurrentUser().getId();
 
         YearMonth currentMonth = YearMonth.of(year, month);
         YearMonth previousMonth = currentMonth.minusMonths(1);
+
         AmountSummaryRow amountSummary = monthlyReportRepository.findAmountSummary(
-                userId,
+                currentUserId,
                 currentMonth.atDay(1),
                 currentMonth.atEndOfMonth(),
                 previousMonth.atDay(1),
@@ -47,12 +48,6 @@ public class GetMonthlyAmountSummaryService {
                         amountSummary.previousIncomeCount()
                 )
         );
-    }
-
-    private void validateUserExists(UUID userId) {
-        if (!userRepository.existsById(userId)) {
-            throw new IllegalArgumentException("사용자를 찾을 수 없습니다. userId=" + userId);
-        }
     }
 
     private MonthlyAmountSummaryResponse.AmountComparison getAmountComparison(

--- a/src/main/java/org/example/bankramenserver/domain/report/service/GetMonthlyCategoryExpenseListService.java
+++ b/src/main/java/org/example/bankramenserver/domain/report/service/GetMonthlyCategoryExpenseListService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.bankramenserver.domain.report.domain.repository.CategoryExpenseRow;
 import org.example.bankramenserver.domain.report.domain.repository.MonthlyReportRepository;
 import org.example.bankramenserver.domain.report.presentation.dto.MonthlyCategoryExpenseListResponse;
-import org.example.bankramenserver.domain.user.domain.repository.UserRepository;
+import org.example.bankramenserver.domain.user.facade.UserFacade;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,17 +18,18 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class GetMonthlyCategoryExpenseListService {
 
-    private final UserRepository userRepository;
+    private final UserFacade userFacade;
     private final MonthlyReportRepository monthlyReportRepository;
 
     @Transactional(readOnly = true)
-    public MonthlyCategoryExpenseListResponse execute(UUID userId, int year, int month) {
-        validateUserExists(userId);
+    public MonthlyCategoryExpenseListResponse execute(int year, int month) {
+        UUID currentUserId = userFacade.getCurrentUser().getId();
 
         YearMonth currentMonth = YearMonth.of(year, month);
         YearMonth previousMonth = currentMonth.minusMonths(1);
+
         List<CategoryExpenseRow> rows = monthlyReportRepository.findCategoryExpenseComparisons(
-                userId,
+                currentUserId,
                 currentMonth.atDay(1),
                 currentMonth.atEndOfMonth(),
                 previousMonth.atDay(1),
@@ -47,12 +48,6 @@ public class GetMonthlyCategoryExpenseListService {
                 totalExpense,
                 categories
         );
-    }
-
-    private void validateUserExists(UUID userId) {
-        if (!userRepository.existsById(userId)) {
-            throw new IllegalArgumentException("사용자를 찾을 수 없습니다. userId=" + userId);
-        }
     }
 
     private MonthlyCategoryExpenseListResponse.CategoryExpense toCategoryExpense(

--- a/src/main/java/org/example/bankramenserver/domain/transaction/presentation/TransactionController.java
+++ b/src/main/java/org/example/bankramenserver/domain/transaction/presentation/TransactionController.java
@@ -7,12 +7,9 @@ import org.example.bankramenserver.domain.transaction.service.GetMonthlyExpenseT
 import org.example.bankramenserver.domain.transaction.service.GetMonthlyIncomeTransactionListService;
 import org.example.bankramenserver.global.document.TransactionApiDocument;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,22 +20,20 @@ public class TransactionController implements TransactionApiDocument {
     private final GetMonthlyExpenseTransactionListService getMonthlyExpenseTransactionListService;
 
     @Override
-    @GetMapping("/incomes/{userId}")
+    @GetMapping("/incomes")
     public MonthlyIncomeTransactionListResponse getMonthlyIncomeTransactions(
-            @PathVariable UUID userId,
             @RequestParam int year,
             @RequestParam int month
     ) {
-        return getMonthlyIncomeTransactionListService.execute(userId, year, month);
+        return getMonthlyIncomeTransactionListService.execute(year, month);
     }
 
     @Override
-    @GetMapping("/expenses/{userId}")
+    @GetMapping("/expenses")
     public MonthlyExpenseTransactionListResponse getMonthlyExpenseTransactions(
-            @PathVariable UUID userId,
             @RequestParam int year,
             @RequestParam int month
     ) {
-        return getMonthlyExpenseTransactionListService.execute(userId, year, month);
+        return getMonthlyExpenseTransactionListService.execute(year, month);
     }
 }

--- a/src/main/java/org/example/bankramenserver/domain/transaction/presentation/dto/TransactionHistoryResponse.java
+++ b/src/main/java/org/example/bankramenserver/domain/transaction/presentation/dto/TransactionHistoryResponse.java
@@ -1,5 +1,6 @@
 package org.example.bankramenserver.domain.transaction.presentation.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import org.example.bankramenserver.domain.category.domain.Category;
@@ -14,8 +15,10 @@ public record TransactionHistoryResponse(
         @Schema(description = "거래 제목 또는 설명", example = "스타벅스 강남점")
         String title,
         @Schema(description = "거래 날짜", example = "2026-08-15")
+        @JsonFormat(pattern = "yyyy-MM-dd")
         LocalDate transactionDate,
         @Schema(description = "거래 시간. 별도 거래 시간이 없으면 생성 시간을 기준으로 응답합니다.", example = "14:30:00", nullable = true)
+        @JsonFormat(pattern = "HH:mm:ss")
         LocalTime transactionTime,
         @Schema(description = "거래 금액", example = "1400")
         long amount,

--- a/src/main/java/org/example/bankramenserver/domain/transaction/service/GetMonthlyExpenseTransactionListService.java
+++ b/src/main/java/org/example/bankramenserver/domain/transaction/service/GetMonthlyExpenseTransactionListService.java
@@ -5,7 +5,7 @@ import org.example.bankramenserver.domain.transaction.domain.Transaction;
 import org.example.bankramenserver.domain.transaction.domain.repository.TransactionRepository;
 import org.example.bankramenserver.domain.transaction.presentation.dto.MonthlyExpenseTransactionListResponse;
 import org.example.bankramenserver.domain.transaction.presentation.dto.TransactionHistoryResponse;
-import org.example.bankramenserver.domain.user.domain.repository.UserRepository;
+import org.example.bankramenserver.domain.user.facade.UserFacade;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,17 +17,17 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class GetMonthlyExpenseTransactionListService {
 
-    private final UserRepository userRepository;
+    private final UserFacade userFacade;
     private final TransactionRepository transactionRepository;
 
     @Transactional(readOnly = true)
-    public MonthlyExpenseTransactionListResponse execute(UUID userId, int year, int month) {
-        validateUserExists(userId);
-
+    public MonthlyExpenseTransactionListResponse execute(int year, int month) {
+        UUID currentUserId = userFacade.getCurrentUser().getId();
         YearMonth yearMonth = YearMonth.of(year, month);
+
         List<TransactionHistoryResponse> expenses = transactionRepository
                 .findTransactionHistories(
-                        userId,
+                        currentUserId,
                         Transaction.TransactionType.EXPENSE,
                         yearMonth.atDay(1),
                         yearMonth.atEndOfMonth()
@@ -37,11 +37,5 @@ public class GetMonthlyExpenseTransactionListService {
                 .toList();
 
         return MonthlyExpenseTransactionListResponse.of(yearMonth, expenses);
-    }
-
-    private void validateUserExists(UUID userId) {
-        if (!userRepository.existsById(userId)) {
-            throw new IllegalArgumentException("사용자를 찾을 수 없습니다. userId=" + userId);
-        }
     }
 }

--- a/src/main/java/org/example/bankramenserver/domain/transaction/service/GetMonthlyIncomeTransactionListService.java
+++ b/src/main/java/org/example/bankramenserver/domain/transaction/service/GetMonthlyIncomeTransactionListService.java
@@ -5,7 +5,7 @@ import org.example.bankramenserver.domain.transaction.domain.Transaction;
 import org.example.bankramenserver.domain.transaction.domain.repository.TransactionRepository;
 import org.example.bankramenserver.domain.transaction.presentation.dto.MonthlyIncomeTransactionListResponse;
 import org.example.bankramenserver.domain.transaction.presentation.dto.TransactionHistoryResponse;
-import org.example.bankramenserver.domain.user.domain.repository.UserRepository;
+import org.example.bankramenserver.domain.user.facade.UserFacade;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,17 +17,17 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class GetMonthlyIncomeTransactionListService {
 
-    private final UserRepository userRepository;
+    private final UserFacade userFacade;
     private final TransactionRepository transactionRepository;
 
     @Transactional(readOnly = true)
-    public MonthlyIncomeTransactionListResponse execute(UUID userId, int year, int month) {
-        validateUserExists(userId);
-
+    public MonthlyIncomeTransactionListResponse execute(int year, int month) {
+        UUID currentUserId = userFacade.getCurrentUser().getId();
         YearMonth yearMonth = YearMonth.of(year, month);
+
         List<TransactionHistoryResponse> incomes = transactionRepository
                 .findTransactionHistories(
-                        userId,
+                        currentUserId,
                         Transaction.TransactionType.INCOME,
                         yearMonth.atDay(1),
                         yearMonth.atEndOfMonth()
@@ -37,11 +37,5 @@ public class GetMonthlyIncomeTransactionListService {
                 .toList();
 
         return MonthlyIncomeTransactionListResponse.of(yearMonth, incomes);
-    }
-
-    private void validateUserExists(UUID userId) {
-        if (!userRepository.existsById(userId)) {
-            throw new IllegalArgumentException("사용자를 찾을 수 없습니다. userId=" + userId);
-        }
     }
 }

--- a/src/main/java/org/example/bankramenserver/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/org/example/bankramenserver/domain/user/exception/UserNotFoundException.java
@@ -1,0 +1,13 @@
+package org.example.bankramenserver.domain.user.exception;
+
+import org.example.bankramenserver.global.error.exception.ErrorCode;
+import org.example.bankramenserver.global.error.exception.GlobalException;
+
+public class UserNotFoundException extends GlobalException {
+
+    public static final GlobalException EXCEPTION = new UserNotFoundException();
+
+    public UserNotFoundException() {
+        super(ErrorCode.USER_NOT_FOUND);
+    }
+}

--- a/src/main/java/org/example/bankramenserver/domain/user/facade/UserFacade.java
+++ b/src/main/java/org/example/bankramenserver/domain/user/facade/UserFacade.java
@@ -1,0 +1,41 @@
+package org.example.bankramenserver.domain.user.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.example.bankramenserver.domain.auth.exception.InvalidTokenException;
+import org.example.bankramenserver.domain.user.domain.User;
+import org.example.bankramenserver.domain.user.domain.repository.UserRepository;
+import org.example.bankramenserver.domain.user.exception.UserNotFoundException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class UserFacade {
+
+    private final UserRepository userRepository;
+
+    public User getCurrentUser() {
+        UUID currentUserId = getCurrentUserId();
+
+        return userRepository.findById(currentUserId)
+                .orElseThrow(() -> UserNotFoundException.EXCEPTION);
+    }
+
+    public UUID getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw InvalidTokenException.EXCEPTION;
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (!(principal instanceof UUID userId)) {
+            throw InvalidTokenException.EXCEPTION;
+        }
+
+        return userId;
+    }
+}

--- a/src/main/java/org/example/bankramenserver/global/config/OpenApiConfig.java
+++ b/src/main/java/org/example/bankramenserver/global/config/OpenApiConfig.java
@@ -1,7 +1,9 @@
 package org.example.bankramenserver.global.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.enums.SecuritySchemeType;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.security.SecurityScheme;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.context.annotation.Configuration;
 
@@ -17,6 +19,12 @@ import org.springframework.context.annotation.Configuration;
                 @Tag(name = "Monthly Report", description = "월별 리포트 조회 API"),
                 @Tag(name = "Transaction", description = "월별 수입/지출 거래 내역 조회 API")
         }
+)
+@SecurityScheme(
+        name = "bearerAuth",
+        type = SecuritySchemeType.HTTP,
+        scheme = "bearer",
+        bearerFormat = "JWT"
 )
 public class OpenApiConfig {
 }

--- a/src/main/java/org/example/bankramenserver/global/config/SecurityConfig.java
+++ b/src/main/java/org/example/bankramenserver/global/config/SecurityConfig.java
@@ -28,6 +28,7 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/v3/api-docs/**").permitAll()
                         .requestMatchers("/auth/kakao/**").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/org/example/bankramenserver/global/document/MonthlyReportApiDocument.java
+++ b/src/main/java/org/example/bankramenserver/global/document/MonthlyReportApiDocument.java
@@ -6,24 +6,23 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 import org.example.bankramenserver.domain.report.presentation.dto.MonthlyAmountSummaryResponse;
 import org.example.bankramenserver.domain.report.presentation.dto.MonthlyCategoryExpenseListResponse;
 import org.springframework.http.MediaType;
-
-import java.util.UUID;
 
 @Tag(name = "Monthly Report", description = "월별 리포트 조회 API")
 public interface MonthlyReportApiDocument {
 
     @Operation(
             summary = "월별 금액 요약 조회",
-            description = "선택한 월의 총 지출과 총 수입을 지난달 금액 및 증감률과 함께 조회합니다.",
+            description = "Authorization 헤더의 액세스 토큰으로 현재 사용자를 식별하고, 선택한 월의 총 지출과 총 수입을 지난달 금액 및 증감률과 함께 조회합니다.",
             tags = {"Monthly Report"}
     )
+    @SecurityRequirement(name = "bearerAuth")
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
@@ -36,8 +35,6 @@ public interface MonthlyReportApiDocument {
             @ApiResponse(responseCode = "400", description = "요청 파라미터 검증 실패", content = @Content)
     })
     MonthlyAmountSummaryResponse getMonthlyAmountSummary(
-            @Parameter(description = "사용자 ID", required = true, example = "550e8400-e29b-41d4-a716-446655440000")
-            @NotNull UUID userId,
             @Parameter(description = "조회 연도", required = true, example = "2026")
             @Min(2000) @Max(2999) int year,
             @Parameter(description = "조회 월", required = true, example = "8")
@@ -46,9 +43,10 @@ public interface MonthlyReportApiDocument {
 
     @Operation(
             summary = "월별 카테고리 지출 목록 조회",
-            description = "선택한 월의 카테고리별 지출 금액, 전체 지출 대비 비율, 지난달보다 더 많이 사용했는지 여부를 조회합니다.",
+            description = "Authorization 헤더의 액세스 토큰으로 현재 사용자를 식별하고, 선택한 월의 카테고리별 지출 금액, 전체 지출 대비 비율, 지난달보다 더 많이 사용했는지 여부를 조회합니다.",
             tags = {"Monthly Report"}
     )
+    @SecurityRequirement(name = "bearerAuth")
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
@@ -61,8 +59,6 @@ public interface MonthlyReportApiDocument {
             @ApiResponse(responseCode = "400", description = "요청 파라미터 검증 실패", content = @Content)
     })
     MonthlyCategoryExpenseListResponse getMonthlyCategoryExpenses(
-            @Parameter(description = "사용자 ID", required = true, example = "550e8400-e29b-41d4-a716-446655440000")
-            @NotNull UUID userId,
             @Parameter(description = "조회 연도", required = true, example = "2026")
             @Min(2000) @Max(2999) int year,
             @Parameter(description = "조회 월", required = true, example = "8")

--- a/src/main/java/org/example/bankramenserver/global/document/TransactionApiDocument.java
+++ b/src/main/java/org/example/bankramenserver/global/document/TransactionApiDocument.java
@@ -6,24 +6,23 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 import org.example.bankramenserver.domain.transaction.presentation.dto.MonthlyExpenseTransactionListResponse;
 import org.example.bankramenserver.domain.transaction.presentation.dto.MonthlyIncomeTransactionListResponse;
 import org.springframework.http.MediaType;
-
-import java.util.UUID;
 
 @Tag(name = "Transaction", description = "월별 수입/지출 거래 내역 조회 API")
 public interface TransactionApiDocument {
 
     @Operation(
             summary = "월별 수입 내역 조회",
-            description = "선택한 월의 수입 거래 내역을 제목, 거래일, 거래시간, 금액, 카테고리 정보와 함께 조회합니다.",
+            description = "Authorization 헤더의 액세스 토큰으로 현재 사용자를 식별하고, 선택한 월의 수입 거래 내역을 제목, 거래일, 거래시간, 금액, 카테고리 정보와 함께 조회합니다.",
             tags = {"Transaction"}
     )
+    @SecurityRequirement(name = "bearerAuth")
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
@@ -37,8 +36,6 @@ public interface TransactionApiDocument {
             @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
     })
     MonthlyIncomeTransactionListResponse getMonthlyIncomeTransactions(
-            @Parameter(description = "사용자 ID", required = true, example = "550e8400-e29b-41d4-a716-446655440000")
-            @NotNull UUID userId,
             @Parameter(description = "조회 연도", required = true, example = "2026")
             @Min(2000) @Max(2999) int year,
             @Parameter(description = "조회 월", required = true, example = "8")
@@ -47,9 +44,10 @@ public interface TransactionApiDocument {
 
     @Operation(
             summary = "월별 지출 내역 조회",
-            description = "선택한 월의 지출 거래 내역을 제목, 거래일, 거래시간, 금액, 카테고리 정보와 함께 조회합니다.",
+            description = "Authorization 헤더의 액세스 토큰으로 현재 사용자를 식별하고, 선택한 월의 지출 거래 내역을 제목, 거래일, 거래시간, 금액, 카테고리 정보와 함께 조회합니다.",
             tags = {"Transaction"}
     )
+    @SecurityRequirement(name = "bearerAuth")
     @ApiResponses({
             @ApiResponse(
                     responseCode = "200",
@@ -63,8 +61,6 @@ public interface TransactionApiDocument {
             @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
     })
     MonthlyExpenseTransactionListResponse getMonthlyExpenseTransactions(
-            @Parameter(description = "사용자 ID", required = true, example = "550e8400-e29b-41d4-a716-446655440000")
-            @NotNull UUID userId,
             @Parameter(description = "조회 연도", required = true, example = "2026")
             @Min(2000) @Max(2999) int year,
             @Parameter(description = "조회 월", required = true, example = "8")

--- a/src/main/java/org/example/bankramenserver/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/bankramenserver/global/jwt/JwtAuthenticationFilter.java
@@ -26,7 +26,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final String[] PERMIT_URLS = {
             "/auth/kakao/login",
-            "/auth/kakao/callback"
+            "/auth/kakao/callback",
+            "/swagger-ui",
+            "/swagger-ui.html",
+            "/v3/api-docs"
     };
 
     @Override

--- a/src/test/java/org/example/bankramenserver/domain/report/presentation/MonthlyReportControllerTest.java
+++ b/src/test/java/org/example/bankramenserver/domain/report/presentation/MonthlyReportControllerTest.java
@@ -16,7 +16,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.math.BigDecimal;
 import java.time.YearMonth;
 import java.util.List;
-import java.util.UUID;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -26,8 +25,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ExtendWith(MockitoExtension.class)
 class MonthlyReportControllerTest {
-
-    private static final UUID USER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
 
     @Mock
     private GetMonthlyAmountSummaryService getMonthlyAmountSummaryService;
@@ -54,9 +51,9 @@ class MonthlyReportControllerTest {
                 MonthlyAmountSummaryResponse.AmountComparison.of(3500000L, 3000000L, BigDecimal.valueOf(16.7))
         );
 
-        when(getMonthlyAmountSummaryService.execute(USER_ID, 2026, 8)).thenReturn(response);
+        when(getMonthlyAmountSummaryService.execute(2026, 8)).thenReturn(response);
 
-        mockMvc.perform(get("/reports/monthly/summary/{userId}", USER_ID)
+        mockMvc.perform(get("/reports/monthly/summary")
                         .param("year", "2026")
                         .param("month", "8"))
                 .andExpect(status().isOk())
@@ -70,7 +67,7 @@ class MonthlyReportControllerTest {
                 .andExpect(jsonPath("$.income.hasPreviousMonthData").value(true))
                 .andExpect(jsonPath("$.income.differenceRate").value(16.7));
 
-        verify(getMonthlyAmountSummaryService).execute(USER_ID, 2026, 8);
+        verify(getMonthlyAmountSummaryService).execute(2026, 8);
     }
 
     @Test
@@ -96,9 +93,9 @@ class MonthlyReportControllerTest {
                 )
         );
 
-        when(getMonthlyCategoryExpenseListService.execute(USER_ID, 2026, 8)).thenReturn(response);
+        when(getMonthlyCategoryExpenseListService.execute(2026, 8)).thenReturn(response);
 
-        mockMvc.perform(get("/reports/monthly/categories/{userId}", USER_ID)
+        mockMvc.perform(get("/reports/monthly/categories")
                         .param("year", "2026")
                         .param("month", "8"))
                 .andExpect(status().isOk())
@@ -112,6 +109,6 @@ class MonthlyReportControllerTest {
                 .andExpect(jsonPath("$.categories[1].category").value("TRANSPORT_CAR"))
                 .andExpect(jsonPath("$.categories[1].spentMoreThanPreviousMonth").value(false));
 
-        verify(getMonthlyCategoryExpenseListService).execute(USER_ID, 2026, 8);
+        verify(getMonthlyCategoryExpenseListService).execute(2026, 8);
     }
 }

--- a/src/test/java/org/example/bankramenserver/domain/transaction/presentation/TransactionControllerTest.java
+++ b/src/test/java/org/example/bankramenserver/domain/transaction/presentation/TransactionControllerTest.java
@@ -18,7 +18,6 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.YearMonth;
 import java.util.List;
-import java.util.UUID;
 
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -28,8 +27,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @ExtendWith(MockitoExtension.class)
 class TransactionControllerTest {
-
-    private static final UUID USER_ID = UUID.fromString("22222222-2222-2222-2222-222222222222");
 
     @Mock
     private GetMonthlyIncomeTransactionListService getMonthlyIncomeTransactionListService;
@@ -62,9 +59,9 @@ class TransactionControllerTest {
                 ))
         );
 
-        when(getMonthlyIncomeTransactionListService.execute(USER_ID, 2026, 8)).thenReturn(response);
+        when(getMonthlyIncomeTransactionListService.execute(2026, 8)).thenReturn(response);
 
-        mockMvc.perform(get("/transactions/incomes/{userId}", USER_ID)
+        mockMvc.perform(get("/transactions/incomes")
                         .param("year", "2026")
                         .param("month", "8"))
                 .andExpect(status().isOk())
@@ -76,7 +73,7 @@ class TransactionControllerTest {
                 .andExpect(jsonPath("$.incomes[0].category").value("SALARY"))
                 .andExpect(jsonPath("$.incomes[0].categoryName").value("급여"));
 
-        verify(getMonthlyIncomeTransactionListService).execute(USER_ID, 2026, 8);
+        verify(getMonthlyIncomeTransactionListService).execute(2026, 8);
     }
 
     @Test
@@ -93,9 +90,9 @@ class TransactionControllerTest {
                 ))
         );
 
-        when(getMonthlyExpenseTransactionListService.execute(USER_ID, 2026, 8)).thenReturn(response);
+        when(getMonthlyExpenseTransactionListService.execute(2026, 8)).thenReturn(response);
 
-        mockMvc.perform(get("/transactions/expenses/{userId}", USER_ID)
+        mockMvc.perform(get("/transactions/expenses")
                         .param("year", "2026")
                         .param("month", "8"))
                 .andExpect(status().isOk())
@@ -107,6 +104,6 @@ class TransactionControllerTest {
                 .andExpect(jsonPath("$.expenses[0].category").value("FOOD"))
                 .andExpect(jsonPath("$.expenses[0].categoryName").value("식비"));
 
-        verify(getMonthlyExpenseTransactionListService).execute(USER_ID, 2026, 8);
+        verify(getMonthlyExpenseTransactionListService).execute(2026, 8);
     }
 }


### PR DESCRIPTION
리포트와 거래 조회 API가 path userId 대신 인증 토큰의 현재 사용자로 데이터를 조회하도록 전환한다. 
UserFacade를 추가해 SecurityContext principal에서 현재 사용자 정보를 가져오고, 사용자 없음 오류는 전역 예외 처리 흐름의 USER_NOT_FOUND로 응답하게 한다.

Swagger 문서와 컨트롤러 테스트도 변경된 요청 형태에 맞춰 갱신한다.

Constraint: 클라이언트가 userId를 직접 전달하지 않고 Authorization 헤더로 사용자를 식별해야 함
Rejected: path userId 유지 | 다른 사용자 ID를 요청할 수 있어 권한 경계가 약해짐
Confidence: high
Scope-risk: moderate
Tested: bash ./gradlew test
Not-tested: 실제 JWT를 포함한 통합 요청

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * API 문서에 OpenAPI 보안 스킴 추가로 인증 토큰 기반 접근 개선

* **리팩토링**
  * 월간 보고서 및 거래 내역 API 엔드포인트에서 경로 매개변수 제거
  * 현재 인증된 사용자 정보를 자동으로 식별하는 메커니즘 구현
  * 모든 API 요청에 인증 토큰 기반 사용자 식별 적용

* **문서**
  * Swagger UI 및 API 문서에 보안 요구사항 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->