### PR TITLE
거래 내역 관리 API 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,28 +1,29 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
-This repository is a Gradle-based Spring Boot backend. Put application code under `src/main/java/org/example`, grouped by feature (`auth`, `user`, `common`, etc.) rather than by framework alone. Keep runtime configuration in `src/main/resources/application.yaml`. Place tests in `src/test/java/org/example` with the same package structure as production code.
-
-Current dependencies indicate a MySQL + JPA + Redis + Spring Security/JWT stack, so keep persistence, cache, and security concerns separated into focused packages.
+This is a Gradle-based Spring Boot 3 backend. Application code lives under `src/main/java/org/example/bankramenserver` and is grouped by domain feature such as `auth`, `user`, `category`, `report`, and `transaction`. Follow the layered package style already in use: `domain`, `presentation`, `presentation/dto`, `service`, `facade`, and `domain/repository` where persistence is needed. Keep shared infrastructure in `global`, including `config`, `error`, `jwt`, and Swagger document interfaces in `global/document`. Tests belong under `src/test/java/org/example/bankramenserver`.
 
 ## Build, Test, and Development Commands
-Use the Gradle wrapper through Bash because `gradlew` is not executable in the current repo state.
+Use the Gradle wrapper through Bash.
 
-- `bash ./gradlew test` — run the JUnit 5 and Spring test suite.
+- `bash ./gradlew test` — run the JUnit 5 test suite.
 - `bash ./gradlew build` — compile, test, and package the app.
 - `bash ./gradlew bootRun` — start the service locally.
 - `bash ./gradlew clean` — remove Gradle build outputs.
 
-The build requires **JDK 26** (`build.gradle` toolchain setting). Export the environment variables referenced in `application.yaml` before running locally, such as `MYSQL_URL`, `REDIS_HOST`, and `JWT_SECRET`.
+The project uses Java toolchain **17**. Export values required by `application.yaml`, such as MySQL, Redis, and JWT settings, before local runtime testing.
 
 ## Coding Style & Naming Conventions
-Use 4-space indentation and keep files formatted consistently with standard Java/Spring conventions. Use lowercase package names, `PascalCase` for classes, `camelCase` for methods/fields, and `UPPER_SNAKE_CASE` for constants. Prefer constructor injection for Spring beans and keep controllers thin; business logic should live in services.
+Use standard Java/Spring conventions with 4-space indentation. Class names use `PascalCase`; methods and fields use `camelCase`; constants use `UPPER_SNAKE_CASE`. Prefer constructor injection with Lombok `@RequiredArgsConstructor`. Keep controllers thin and delegate business logic to services. Use record DTOs for immutable request/response shapes and builders when construction readability improves.
+
+## API, Security & Error Handling
+Protected APIs should identify the current user from the JWT security context through `UserFacade`; do not accept `userId` path parameters for user-owned report or transaction data. Keep auth rules explicit in `SecurityConfig`. Define Swagger/OpenAPI annotations in `global/document` interfaces and have controllers implement them. Use `GlobalException` plus `ErrorCode`; avoid hard-coded `IllegalArgumentException` for domain/API failures.
+
+## Persistence & Querying
+Use Spring Data JPA repositories and Querydsl custom repositories for complex reads. Name custom contracts like `TransactionRepositoryCustom` and implement with `TransactionRepositoryImpl`. Keep query projection records close to the repository package.
 
 ## Testing Guidelines
-Use `spring-boot-starter-test` and `spring-security-test`. Name tests `*Test` and mirror the production package structure. Add focused unit tests for services/utilities and use slice or integration tests only when framework wiring matters. No coverage gate is configured yet, but new behavior should ship with regression tests.
+Use `spring-boot-starter-test`, Mockito, and `MockMvcBuilders.standaloneSetup()` for focused controller tests. Name test classes `*Test`. Verify response JSON contracts, status codes, and service invocation parameters. Add integration tests only when framework wiring or persistence must be proven.
 
 ## Commit & Pull Request Guidelines
-Recent history follows a short conventional style such as `chore(#1): remove unused entity` and `init(#1): setting`. Keep that `type(#issue): summary` pattern, and include rationale plus verification details in the PR description. For API or security changes, add sample requests/responses, changed environment variables, and linked issue numbers.
-
-## Security & Configuration Tips
-Never hardcode secrets. Keep all database, Redis, and JWT values in environment variables. If you change auth, persistence, or cache settings, document the required config changes in the PR.
+Follow the existing `type(#issue): summary` commit style, e.g. `feat(#9): 리포트 거래 API 인증 명시`. Keep commits focused and include rationale plus verification details in PRs. For API or security changes, document changed endpoints, auth requirements, example requests/responses, and required environment variables.

--- a/src/main/java/org/example/bankramenserver/domain/transaction/domain/Transaction.java
+++ b/src/main/java/org/example/bankramenserver/domain/transaction/domain/Transaction.java
@@ -19,7 +19,8 @@ import java.util.UUID;
 @Table(name = "transactions",
         indexes = {
                 @Index(name = "idx_transaction_user_type_date", columnList = "user_id, type, transaction_date"),
-                @Index(name = "idx_transaction_user_category", columnList = "user_id, category")
+                @Index(name = "idx_transaction_user_category", columnList = "user_id, category"),
+                @Index(name = "idx_transaction_user_date", columnList = "user_id, transaction_date")
         })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/org/example/bankramenserver/domain/transaction/domain/repository/TransactionHistoryRow.java
+++ b/src/main/java/org/example/bankramenserver/domain/transaction/domain/repository/TransactionHistoryRow.java
@@ -2,15 +2,19 @@ package org.example.bankramenserver.domain.transaction.domain.repository;
 
 import lombok.Builder;
 import org.example.bankramenserver.domain.category.domain.Category;
+import org.example.bankramenserver.domain.transaction.domain.Transaction;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Builder
 public record TransactionHistoryRow(
+        UUID transactionId,
         String title,
         LocalDate transactionDate,
         LocalDateTime createdAt,
         Long amount,
+        Transaction.TransactionType type,
         Category category
 ) { }

--- a/src/main/java/org/example/bankramenserver/domain/transaction/domain/repository/TransactionRepository.java
+++ b/src/main/java/org/example/bankramenserver/domain/transaction/domain/repository/TransactionRepository.java
@@ -3,7 +3,10 @@ package org.example.bankramenserver.domain.transaction.domain.repository;
 import org.example.bankramenserver.domain.transaction.domain.Transaction;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface TransactionRepository extends JpaRepository<Transaction, UUID>, TransactionRepositoryCustom {
+
+    Optional<Transaction> findByIdAndUser_Id(UUID transactionId, UUID userId);
 }

--- a/src/main/java/org/example/bankramenserver/domain/transaction/domain/repository/TransactionRepositoryCustom.java
+++ b/src/main/java/org/example/bankramenserver/domain/transaction/domain/repository/TransactionRepositoryCustom.java
@@ -14,4 +14,9 @@ public interface TransactionRepositoryCustom {
             LocalDate startDate,
             LocalDate endDate
     );
+
+    List<TransactionHistoryRow> findRecentTransactionHistories(
+            UUID userId,
+            int limit
+    );
 }

--- a/src/main/java/org/example/bankramenserver/domain/transaction/domain/repository/TransactionRepositoryImpl.java
+++ b/src/main/java/org/example/bankramenserver/domain/transaction/domain/repository/TransactionRepositoryImpl.java
@@ -29,10 +29,12 @@ public class TransactionRepositoryImpl implements TransactionRepositoryCustom {
         return jpaQueryFactory
                 .select(Projections.constructor(
                         TransactionHistoryRow.class,
+                        transaction.id,
                         transaction.description,
                         transaction.transactionDate,
                         transaction.createdAt,
                         transaction.amount,
+                        transaction.type,
                         transaction.category
                 ))
                 .from(transaction)
@@ -46,6 +48,33 @@ public class TransactionRepositoryImpl implements TransactionRepositoryCustom {
                         transaction.createdAt.desc(),
                         transaction.id.desc()
                 )
+                .fetch();
+    }
+
+    @Override
+    public List<TransactionHistoryRow> findRecentTransactionHistories(
+            UUID userId,
+            int limit
+    ) {
+        return jpaQueryFactory
+                .select(Projections.constructor(
+                        TransactionHistoryRow.class,
+                        transaction.id,
+                        transaction.description,
+                        transaction.transactionDate,
+                        transaction.createdAt,
+                        transaction.amount,
+                        transaction.type,
+                        transaction.category
+                ))
+                .from(transaction)
+                .where(transaction.user.id.eq(userId))
+                .orderBy(
+                        transaction.transactionDate.desc(),
+                        transaction.createdAt.desc(),
+                        transaction.id.desc()
+                )
+                .limit(limit)
                 .fetch();
     }
 }

--- a/src/main/java/org/example/bankramenserver/domain/transaction/exception/TransactionNotFoundException.java
+++ b/src/main/java/org/example/bankramenserver/domain/transaction/exception/TransactionNotFoundException.java
@@ -1,0 +1,13 @@
+package org.example.bankramenserver.domain.transaction.exception;
+
+import org.example.bankramenserver.global.error.exception.ErrorCode;
+import org.example.bankramenserver.global.error.exception.GlobalException;
+
+public class TransactionNotFoundException extends GlobalException {
+
+    public static final GlobalException EXCEPTION = new TransactionNotFoundException();
+
+    public TransactionNotFoundException() {
+        super(ErrorCode.TRANSACTION_NOT_FOUND);
+    }
+}

--- a/src/main/java/org/example/bankramenserver/domain/transaction/presentation/TransactionController.java
+++ b/src/main/java/org/example/bankramenserver/domain/transaction/presentation/TransactionController.java
@@ -1,15 +1,32 @@
 package org.example.bankramenserver.domain.transaction.presentation;
 
 import lombok.RequiredArgsConstructor;
+import org.example.bankramenserver.domain.transaction.presentation.dto.CreateTransactionRequest;
 import org.example.bankramenserver.domain.transaction.presentation.dto.MonthlyExpenseTransactionListResponse;
 import org.example.bankramenserver.domain.transaction.presentation.dto.MonthlyIncomeTransactionListResponse;
+import org.example.bankramenserver.domain.transaction.presentation.dto.RecentTransactionListResponse;
+import org.example.bankramenserver.domain.transaction.presentation.dto.TransactionHistoryResponse;
+import org.example.bankramenserver.domain.transaction.presentation.dto.UpdateTransactionCategoryRequest;
+import org.example.bankramenserver.domain.transaction.service.CreateTransactionService;
+import org.example.bankramenserver.domain.transaction.service.DeleteTransactionService;
+import org.example.bankramenserver.domain.transaction.service.GetRecentTransactionListService;
 import org.example.bankramenserver.domain.transaction.service.GetMonthlyExpenseTransactionListService;
 import org.example.bankramenserver.domain.transaction.service.GetMonthlyIncomeTransactionListService;
+import org.example.bankramenserver.domain.transaction.service.UpdateTransactionCategoryService;
 import org.example.bankramenserver.global.document.TransactionApiDocument;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,6 +35,41 @@ public class TransactionController implements TransactionApiDocument {
 
     private final GetMonthlyIncomeTransactionListService getMonthlyIncomeTransactionListService;
     private final GetMonthlyExpenseTransactionListService getMonthlyExpenseTransactionListService;
+    private final GetRecentTransactionListService getRecentTransactionListService;
+    private final CreateTransactionService createTransactionService;
+    private final DeleteTransactionService deleteTransactionService;
+    private final UpdateTransactionCategoryService updateTransactionCategoryService;
+
+    @Override
+    @GetMapping("/recent")
+    public RecentTransactionListResponse getRecentTransactions(@RequestParam(defaultValue = "5") int limit) {
+        return getRecentTransactionListService.execute(limit);
+    }
+
+    @Override
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public void createTransaction(@RequestBody CreateTransactionRequest request) {
+        createTransactionService.execute(request);
+    }
+
+    @Override
+    @DeleteMapping("/{transactionId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteTransaction(
+            @PathVariable UUID transactionId
+    ) {
+        deleteTransactionService.execute(transactionId);
+    }
+
+    @Override
+    @PatchMapping("/{transactionId}/category")
+    public TransactionHistoryResponse updateTransactionCategory(
+            @PathVariable UUID transactionId,
+            @RequestBody UpdateTransactionCategoryRequest request
+    ) {
+        return updateTransactionCategoryService.execute(transactionId, request);
+    }
 
     @Override
     @GetMapping("/incomes")

--- a/src/main/java/org/example/bankramenserver/domain/transaction/presentation/dto/CreateTransactionRequest.java
+++ b/src/main/java/org/example/bankramenserver/domain/transaction/presentation/dto/CreateTransactionRequest.java
@@ -1,0 +1,36 @@
+package org.example.bankramenserver.domain.transaction.presentation.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import org.example.bankramenserver.domain.category.domain.Category;
+import org.example.bankramenserver.domain.transaction.domain.Transaction;
+
+import java.time.LocalDate;
+
+@Schema(description = "거래 내역 추가 요청")
+public record CreateTransactionRequest(
+        @Schema(description = "거래 유형", example = "EXPENSE")
+        @NotNull
+        Transaction.TransactionType type,
+
+        @Schema(description = "거래 금액", example = "4500")
+        @NotNull @Positive
+        Long amount,
+
+        @Schema(description = "거래 제목 또는 사용처", example = "스타벅스 강남점")
+        @NotBlank
+        String title,
+
+        @Schema(description = "카테고리 enum 코드", example = "FOOD")
+        @NotNull
+        Category category,
+
+        @Schema(description = "거래 날짜", example = "2026-08-15")
+        @NotNull
+        @JsonFormat(pattern = "yyyy-MM-dd")
+        LocalDate transactionDate
+) {
+}

--- a/src/main/java/org/example/bankramenserver/domain/transaction/presentation/dto/RecentTransactionListResponse.java
+++ b/src/main/java/org/example/bankramenserver/domain/transaction/presentation/dto/RecentTransactionListResponse.java
@@ -1,0 +1,20 @@
+package org.example.bankramenserver.domain.transaction.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+@Schema(description = "최근 거래 내역 목록 응답")
+public record RecentTransactionListResponse(
+        @Schema(description = "최근 거래 내역 목록")
+        List<TransactionHistoryResponse> transactions
+) {
+
+    public static RecentTransactionListResponse from(List<TransactionHistoryResponse> transactions) {
+        return RecentTransactionListResponse.builder()
+                .transactions(transactions)
+                .build();
+    }
+}

--- a/src/main/java/org/example/bankramenserver/domain/transaction/presentation/dto/TransactionHistoryResponse.java
+++ b/src/main/java/org/example/bankramenserver/domain/transaction/presentation/dto/TransactionHistoryResponse.java
@@ -4,14 +4,19 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import org.example.bankramenserver.domain.category.domain.Category;
+import org.example.bankramenserver.domain.transaction.domain.Transaction;
 import org.example.bankramenserver.domain.transaction.domain.repository.TransactionHistoryRow;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.UUID;
 
 @Builder
 @Schema(description = "거래 내역 응답")
 public record TransactionHistoryResponse(
+        @Schema(description = "거래 내역 ID", example = "550e8400-e29b-41d4-a716-446655440000")
+        UUID transactionId,
         @Schema(description = "거래 제목 또는 설명", example = "스타벅스 강남점")
         String title,
         @Schema(description = "거래 날짜", example = "2026-08-15")
@@ -22,6 +27,8 @@ public record TransactionHistoryResponse(
         LocalTime transactionTime,
         @Schema(description = "거래 금액", example = "1400")
         long amount,
+        @Schema(description = "거래 유형", example = "EXPENSE")
+        Transaction.TransactionType type,
         @Schema(description = "카테고리 enum 코드", example = "FOOD")
         Category category,
         @Schema(description = "사용자에게 표시할 카테고리명", example = "식비")
@@ -32,20 +39,41 @@ public record TransactionHistoryResponse(
         Category category = transactionHistoryRow.category();
 
         return TransactionHistoryResponse.builder()
+                .transactionId(transactionHistoryRow.transactionId())
                 .title(transactionHistoryRow.title())
                 .transactionDate(transactionHistoryRow.transactionDate())
                 .transactionTime(resolveTransactionTime(transactionHistoryRow))
                 .amount(transactionHistoryRow.amount() == null ? 0L : transactionHistoryRow.amount())
+                .type(transactionHistoryRow.type())
+                .category(category)
+                .categoryName(category.getDisplayName())
+                .build();
+    }
+
+    public static TransactionHistoryResponse from(Transaction transaction) {
+        Category category = transaction.getCategory();
+
+        return TransactionHistoryResponse.builder()
+                .transactionId(transaction.getId())
+                .title(transaction.getDescription())
+                .transactionDate(transaction.getTransactionDate())
+                .transactionTime(resolveTransactionTime(transaction.getCreatedAt()))
+                .amount(transaction.getAmount() == null ? 0L : transaction.getAmount())
+                .type(transaction.getType())
                 .category(category)
                 .categoryName(category.getDisplayName())
                 .build();
     }
 
     private static LocalTime resolveTransactionTime(TransactionHistoryRow transactionHistoryRow) {
-        if (transactionHistoryRow.createdAt() == null) {
+        return resolveTransactionTime(transactionHistoryRow.createdAt());
+    }
+
+    private static LocalTime resolveTransactionTime(LocalDateTime createdAt) {
+        if (createdAt == null) {
             return null;
         }
 
-        return transactionHistoryRow.createdAt().toLocalTime();
+        return createdAt.toLocalTime();
     }
 }

--- a/src/main/java/org/example/bankramenserver/domain/transaction/presentation/dto/UpdateTransactionCategoryRequest.java
+++ b/src/main/java/org/example/bankramenserver/domain/transaction/presentation/dto/UpdateTransactionCategoryRequest.java
@@ -1,0 +1,13 @@
+package org.example.bankramenserver.domain.transaction.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import org.example.bankramenserver.domain.category.domain.Category;
+
+@Schema(description = "거래 내역 카테고리 변경 요청")
+public record UpdateTransactionCategoryRequest(
+        @Schema(description = "변경할 카테고리 enum 코드", example = "FOOD")
+        @NotNull
+        Category category
+) {
+}

--- a/src/main/java/org/example/bankramenserver/domain/transaction/service/CreateTransactionService.java
+++ b/src/main/java/org/example/bankramenserver/domain/transaction/service/CreateTransactionService.java
@@ -1,0 +1,34 @@
+package org.example.bankramenserver.domain.transaction.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.bankramenserver.domain.transaction.domain.Transaction;
+import org.example.bankramenserver.domain.transaction.domain.repository.TransactionRepository;
+import org.example.bankramenserver.domain.transaction.presentation.dto.CreateTransactionRequest;
+import org.example.bankramenserver.domain.user.domain.User;
+import org.example.bankramenserver.domain.user.facade.UserFacade;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CreateTransactionService {
+
+    private final UserFacade userFacade;
+    private final TransactionRepository transactionRepository;
+
+    @Transactional
+    public void execute(CreateTransactionRequest request) {
+        User currentUser = userFacade.getCurrentUser();
+        Transaction transaction = Transaction.builder()
+                .user(currentUser)
+                .category(request.category())
+                .type(request.type())
+                .amount(request.amount())
+                .description(request.title())
+                .source(Transaction.TransactionSource.MANUAL)
+                .transactionDate(request.transactionDate())
+                .build();
+
+        transactionRepository.save(transaction);
+    }
+}

--- a/src/main/java/org/example/bankramenserver/domain/transaction/service/DeleteTransactionService.java
+++ b/src/main/java/org/example/bankramenserver/domain/transaction/service/DeleteTransactionService.java
@@ -1,0 +1,28 @@
+package org.example.bankramenserver.domain.transaction.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.bankramenserver.domain.transaction.domain.Transaction;
+import org.example.bankramenserver.domain.transaction.domain.repository.TransactionRepository;
+import org.example.bankramenserver.domain.transaction.exception.TransactionNotFoundException;
+import org.example.bankramenserver.domain.user.facade.UserFacade;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteTransactionService {
+
+    private final UserFacade userFacade;
+    private final TransactionRepository transactionRepository;
+
+    @Transactional
+    public void execute(UUID transactionId) {
+        UUID currentUserId = userFacade.getCurrentUser().getId();
+        Transaction transaction = transactionRepository.findByIdAndUser_Id(transactionId, currentUserId)
+                .orElseThrow(() -> TransactionNotFoundException.EXCEPTION);
+
+        transactionRepository.delete(transaction);
+    }
+}

--- a/src/main/java/org/example/bankramenserver/domain/transaction/service/GetRecentTransactionListService.java
+++ b/src/main/java/org/example/bankramenserver/domain/transaction/service/GetRecentTransactionListService.java
@@ -1,0 +1,31 @@
+package org.example.bankramenserver.domain.transaction.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.bankramenserver.domain.transaction.domain.repository.TransactionRepository;
+import org.example.bankramenserver.domain.transaction.presentation.dto.RecentTransactionListResponse;
+import org.example.bankramenserver.domain.transaction.presentation.dto.TransactionHistoryResponse;
+import org.example.bankramenserver.domain.user.facade.UserFacade;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class GetRecentTransactionListService {
+
+    private final UserFacade userFacade;
+    private final TransactionRepository transactionRepository;
+
+    @Transactional(readOnly = true)
+    public RecentTransactionListResponse execute(int limit) {
+        UUID currentUserId = userFacade.getCurrentUser().getId();
+
+        return RecentTransactionListResponse.from(
+                transactionRepository.findRecentTransactionHistories(currentUserId, limit)
+                        .stream()
+                        .map(TransactionHistoryResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/example/bankramenserver/domain/transaction/service/UpdateTransactionCategoryService.java
+++ b/src/main/java/org/example/bankramenserver/domain/transaction/service/UpdateTransactionCategoryService.java
@@ -1,0 +1,32 @@
+package org.example.bankramenserver.domain.transaction.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.bankramenserver.domain.transaction.domain.Transaction;
+import org.example.bankramenserver.domain.transaction.domain.repository.TransactionRepository;
+import org.example.bankramenserver.domain.transaction.exception.TransactionNotFoundException;
+import org.example.bankramenserver.domain.transaction.presentation.dto.TransactionHistoryResponse;
+import org.example.bankramenserver.domain.transaction.presentation.dto.UpdateTransactionCategoryRequest;
+import org.example.bankramenserver.domain.user.facade.UserFacade;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class UpdateTransactionCategoryService {
+
+    private final UserFacade userFacade;
+    private final TransactionRepository transactionRepository;
+
+    @Transactional
+    public TransactionHistoryResponse execute(UUID transactionId, UpdateTransactionCategoryRequest request) {
+        UUID currentUserId = userFacade.getCurrentUser().getId();
+        Transaction transaction = transactionRepository.findByIdAndUser_Id(transactionId, currentUserId)
+                .orElseThrow(() -> TransactionNotFoundException.EXCEPTION);
+
+        transaction.updateCategory(request.category());
+
+        return TransactionHistoryResponse.from(transaction);
+    }
+}

--- a/src/main/java/org/example/bankramenserver/global/config/OpenApiConfig.java
+++ b/src/main/java/org/example/bankramenserver/global/config/OpenApiConfig.java
@@ -17,7 +17,7 @@ import org.springframework.context.annotation.Configuration;
         tags = {
                 @Tag(name = "Category", description = "기본 제공 카테고리 조회 API"),
                 @Tag(name = "Monthly Report", description = "월별 리포트 조회 API"),
-                @Tag(name = "Transaction", description = "월별 수입/지출 거래 내역 조회 API")
+                @Tag(name = "Transaction", description = "거래 내역 조회 및 관리 API")
         }
 )
 @SecurityScheme(

--- a/src/main/java/org/example/bankramenserver/global/document/TransactionApiDocument.java
+++ b/src/main/java/org/example/bankramenserver/global/document/TransactionApiDocument.java
@@ -4,18 +4,117 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import org.example.bankramenserver.domain.transaction.presentation.dto.CreateTransactionRequest;
 import org.example.bankramenserver.domain.transaction.presentation.dto.MonthlyExpenseTransactionListResponse;
 import org.example.bankramenserver.domain.transaction.presentation.dto.MonthlyIncomeTransactionListResponse;
+import org.example.bankramenserver.domain.transaction.presentation.dto.RecentTransactionListResponse;
+import org.example.bankramenserver.domain.transaction.presentation.dto.TransactionHistoryResponse;
+import org.example.bankramenserver.domain.transaction.presentation.dto.UpdateTransactionCategoryRequest;
 import org.springframework.http.MediaType;
 
-@Tag(name = "Transaction", description = "월별 수입/지출 거래 내역 조회 API")
+import java.util.UUID;
+
+@Tag(name = "Transaction", description = "거래 내역 조회 및 관리 API")
 public interface TransactionApiDocument {
+
+    @Operation(
+            summary = "최근 거래 내역 조회",
+            description = "Authorization 헤더의 액세스 토큰으로 현재 사용자를 식별하고, 최신 거래 내역을 조회합니다.",
+            tags = {"Transaction"}
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "최근 거래 내역 조회 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = RecentTransactionListResponse.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "요청 파라미터 검증 실패", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    })
+    RecentTransactionListResponse getRecentTransactions(
+            @Parameter(description = "조회할 최근 거래 내역 개수", required = true, example = "5")
+            @Min(1) @Max(50) int limit
+    );
+
+    @Operation(
+            summary = "거래 내역 추가",
+            description = "Authorization 헤더의 액세스 토큰으로 현재 사용자를 식별하고, 수입 또는 지출 거래 내역을 직접 추가합니다.",
+            tags = {"Transaction"}
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "거래 내역 추가 성공", content = @Content),
+            @ApiResponse(responseCode = "400", description = "요청 본문 검증 실패", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content)
+    })
+    void createTransaction(
+            @RequestBody(
+                    required = true,
+                    description = "추가할 거래 내역 정보",
+                    content = @Content(schema = @Schema(implementation = CreateTransactionRequest.class))
+            )
+            @Valid
+            CreateTransactionRequest request
+    );
+
+    @Operation(
+            summary = "거래 내역 삭제",
+            description = "Authorization 헤더의 액세스 토큰으로 현재 사용자를 식별하고, 본인의 거래 내역을 삭제합니다.",
+            tags = {"Transaction"}
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "거래 내역 삭제 성공", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+            @ApiResponse(responseCode = "404", description = "거래 내역 없음", content = @Content)
+    })
+    void deleteTransaction(
+            @Parameter(description = "거래 내역 ID", required = true, example = "550e8400-e29b-41d4-a716-446655440000")
+            UUID transactionId
+    );
+
+    @Operation(
+            summary = "거래 내역 카테고리 변경",
+            description = "Authorization 헤더의 액세스 토큰으로 현재 사용자를 식별하고, 본인의 거래 내역 카테고리를 변경합니다.",
+            tags = {"Transaction"}
+    )
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "거래 내역 카테고리 변경 성공",
+                    content = @Content(
+                            mediaType = MediaType.APPLICATION_JSON_VALUE,
+                            schema = @Schema(implementation = TransactionHistoryResponse.class)
+                    )
+            ),
+            @ApiResponse(responseCode = "400", description = "요청 본문 검증 실패", content = @Content),
+            @ApiResponse(responseCode = "401", description = "인증 실패", content = @Content),
+            @ApiResponse(responseCode = "404", description = "거래 내역 없음", content = @Content)
+    })
+    TransactionHistoryResponse updateTransactionCategory(
+            @Parameter(description = "거래 내역 ID", required = true, example = "550e8400-e29b-41d4-a716-446655440000")
+            UUID transactionId,
+            @RequestBody(
+                    required = true,
+                    description = "변경할 카테고리 정보",
+                    content = @Content(schema = @Schema(implementation = UpdateTransactionCategoryRequest.class))
+            )
+            @Valid
+            UpdateTransactionCategoryRequest request
+    );
 
     @Operation(
             summary = "월별 수입 내역 조회",

--- a/src/main/java/org/example/bankramenserver/global/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/example/bankramenserver/global/error/GlobalExceptionHandler.java
@@ -1,11 +1,16 @@
 package org.example.bankramenserver.global.error;
 
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.example.bankramenserver.global.error.exception.GlobalException;
 import org.example.bankramenserver.global.error.exception.ErrorCode;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 
 @Slf4j
 @RestControllerAdvice
@@ -18,6 +23,20 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .status(errorCode.getStatus())
                 .body(ErrorResponse.of(errorCode));
+    }
+
+    @ExceptionHandler({
+            MethodArgumentNotValidException.class,
+            ConstraintViolationException.class,
+            HttpMessageNotReadableException.class,
+            MethodArgumentTypeMismatchException.class,
+            MissingServletRequestParameterException.class
+    })
+    public ResponseEntity<ErrorResponse> handleInvalidRequest(Exception e) {
+        log.error("InvalidRequestException: {}", e.getMessage());
+        return ResponseEntity
+                .status(ErrorCode.INVALID_REQUEST.getStatus())
+                .body(ErrorResponse.of(ErrorCode.INVALID_REQUEST));
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/org/example/bankramenserver/global/error/exception/ErrorCode.java
+++ b/src/main/java/org/example/bankramenserver/global/error/exception/ErrorCode.java
@@ -20,7 +20,11 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     USER_INFO_NOT_FOUND(HttpStatus.NOT_FOUND, "유저 정보가 없습니다."),
 
+    // Transaction
+    TRANSACTION_NOT_FOUND(HttpStatus.NOT_FOUND, "거래 내역을 찾을 수 없습니다."),
+
     // Common
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
 
     private final HttpStatus status;

--- a/src/test/java/org/example/bankramenserver/domain/transaction/presentation/TransactionControllerTest.java
+++ b/src/test/java/org/example/bankramenserver/domain/transaction/presentation/TransactionControllerTest.java
@@ -1,16 +1,23 @@
 package org.example.bankramenserver.domain.transaction.presentation;
 
 import org.example.bankramenserver.domain.category.domain.Category;
+import org.example.bankramenserver.domain.transaction.domain.Transaction;
 import org.example.bankramenserver.domain.transaction.presentation.dto.MonthlyExpenseTransactionListResponse;
 import org.example.bankramenserver.domain.transaction.presentation.dto.MonthlyIncomeTransactionListResponse;
+import org.example.bankramenserver.domain.transaction.presentation.dto.RecentTransactionListResponse;
 import org.example.bankramenserver.domain.transaction.presentation.dto.TransactionHistoryResponse;
+import org.example.bankramenserver.domain.transaction.service.CreateTransactionService;
+import org.example.bankramenserver.domain.transaction.service.DeleteTransactionService;
 import org.example.bankramenserver.domain.transaction.service.GetMonthlyExpenseTransactionListService;
 import org.example.bankramenserver.domain.transaction.service.GetMonthlyIncomeTransactionListService;
+import org.example.bankramenserver.domain.transaction.service.GetRecentTransactionListService;
+import org.example.bankramenserver.domain.transaction.service.UpdateTransactionCategoryService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -18,15 +25,24 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.YearMonth;
 import java.util.List;
+import java.util.UUID;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
 class TransactionControllerTest {
+
+    private static final UUID TRANSACTION_ID = UUID.fromString("33333333-3333-3333-3333-333333333333");
 
     @Mock
     private GetMonthlyIncomeTransactionListService getMonthlyIncomeTransactionListService;
@@ -34,29 +50,122 @@ class TransactionControllerTest {
     @Mock
     private GetMonthlyExpenseTransactionListService getMonthlyExpenseTransactionListService;
 
+    @Mock
+    private GetRecentTransactionListService getRecentTransactionListService;
+
+    @Mock
+    private CreateTransactionService createTransactionService;
+
+    @Mock
+    private DeleteTransactionService deleteTransactionService;
+
+    @Mock
+    private UpdateTransactionCategoryService updateTransactionCategoryService;
+
     private MockMvc mockMvc;
 
     @BeforeEach
     void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(new TransactionController(
                         getMonthlyIncomeTransactionListService,
-                        getMonthlyExpenseTransactionListService
+                        getMonthlyExpenseTransactionListService,
+                        getRecentTransactionListService,
+                        createTransactionService,
+                        deleteTransactionService,
+                        updateTransactionCategoryService
                 ))
                 .build();
+    }
+
+    @Test
+    void getRecentTransactionsReturnsRecentHistories() throws Exception {
+        RecentTransactionListResponse response = RecentTransactionListResponse.from(
+                List.of(expenseResponse("스타벅스 강남점", 4500L, Category.FOOD))
+        );
+
+        when(getRecentTransactionListService.execute(5)).thenReturn(response);
+
+        mockMvc.perform(get("/transactions/recent")
+                        .param("limit", "5"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.transactions[0].transactionId").value(TRANSACTION_ID.toString()))
+                .andExpect(jsonPath("$.transactions[0].title").value("스타벅스 강남점"))
+                .andExpect(jsonPath("$.transactions[0].amount").value(4500))
+                .andExpect(jsonPath("$.transactions[0].type").value("EXPENSE"))
+                .andExpect(jsonPath("$.transactions[0].category").value("FOOD"));
+
+        verify(getRecentTransactionListService).execute(5);
+    }
+
+    @Test
+    void createTransactionReturnsCreated() throws Exception {
+        mockMvc.perform(post("/transactions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "type": "EXPENSE",
+                                  "amount": 4500,
+                                  "title": "스타벅스 강남점",
+                                  "category": "FOOD",
+                                  "transactionDate": "2026-08-12"
+                                }
+                                """))
+                .andExpect(status().isCreated());
+
+        verify(createTransactionService).execute(any());
+    }
+
+    @Test
+    void createTransactionRejectsInvalidRequest() throws Exception {
+        mockMvc.perform(post("/transactions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "type": "EXPENSE",
+                                  "amount": 0,
+                                  "title": "",
+                                  "category": "FOOD",
+                                  "transactionDate": "2026-08-12"
+                                }
+                                """))
+                .andExpect(status().isBadRequest());
+
+        verifyNoInteractions(createTransactionService);
+    }
+
+    @Test
+    void deleteTransactionReturnsNoContent() throws Exception {
+        mockMvc.perform(delete("/transactions/{transactionId}", TRANSACTION_ID))
+                .andExpect(status().isNoContent());
+
+        verify(deleteTransactionService).execute(TRANSACTION_ID);
+    }
+
+    @Test
+    void updateTransactionCategoryReturnsUpdatedTransaction() throws Exception {
+        TransactionHistoryResponse response = expenseResponse("스타벅스 강남점", 4500L, Category.CAFE_SNACK);
+        when(updateTransactionCategoryService.execute(eq(TRANSACTION_ID), any())).thenReturn(response);
+
+        mockMvc.perform(patch("/transactions/{transactionId}/category", TRANSACTION_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "category": "CAFE_SNACK"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.transactionId").value(TRANSACTION_ID.toString()))
+                .andExpect(jsonPath("$.category").value("CAFE_SNACK"))
+                .andExpect(jsonPath("$.categoryName").value("카페/간식"));
+
+        verify(updateTransactionCategoryService).execute(eq(TRANSACTION_ID), any());
     }
 
     @Test
     void getMonthlyIncomeTransactionsReturnsIncomeHistories() throws Exception {
         MonthlyIncomeTransactionListResponse response = MonthlyIncomeTransactionListResponse.of(
                 YearMonth.of(2026, 8),
-                List.of(new TransactionHistoryResponse(
-                        "월급",
-                        LocalDate.of(2026, 8, 25),
-                        LocalTime.of(9, 30),
-                        3500000L,
-                        Category.SALARY,
-                        "급여"
-                ))
+                List.of(incomeResponse("월급", 3500000L, Category.SALARY))
         );
 
         when(getMonthlyIncomeTransactionListService.execute(2026, 8)).thenReturn(response);
@@ -70,6 +179,7 @@ class TransactionControllerTest {
                 .andExpect(jsonPath("$.incomes[0].transactionDate").value("2026-08-25"))
                 .andExpect(jsonPath("$.incomes[0].transactionTime").value("09:30:00"))
                 .andExpect(jsonPath("$.incomes[0].amount").value(3500000))
+                .andExpect(jsonPath("$.incomes[0].type").value("INCOME"))
                 .andExpect(jsonPath("$.incomes[0].category").value("SALARY"))
                 .andExpect(jsonPath("$.incomes[0].categoryName").value("급여"));
 
@@ -80,14 +190,7 @@ class TransactionControllerTest {
     void getMonthlyExpenseTransactionsReturnsExpenseHistories() throws Exception {
         MonthlyExpenseTransactionListResponse response = MonthlyExpenseTransactionListResponse.of(
                 YearMonth.of(2026, 8),
-                List.of(new TransactionHistoryResponse(
-                        "스타벅스 강남점",
-                        LocalDate.of(2026, 8, 12),
-                        LocalTime.of(14, 30),
-                        1400L,
-                        Category.FOOD,
-                        "식비"
-                ))
+                List.of(expenseResponse("스타벅스 강남점", 1400L, Category.FOOD))
         );
 
         when(getMonthlyExpenseTransactionListService.execute(2026, 8)).thenReturn(response);
@@ -101,9 +204,36 @@ class TransactionControllerTest {
                 .andExpect(jsonPath("$.expenses[0].transactionDate").value("2026-08-12"))
                 .andExpect(jsonPath("$.expenses[0].transactionTime").value("14:30:00"))
                 .andExpect(jsonPath("$.expenses[0].amount").value(1400))
+                .andExpect(jsonPath("$.expenses[0].type").value("EXPENSE"))
                 .andExpect(jsonPath("$.expenses[0].category").value("FOOD"))
                 .andExpect(jsonPath("$.expenses[0].categoryName").value("식비"));
 
         verify(getMonthlyExpenseTransactionListService).execute(2026, 8);
+    }
+
+    private TransactionHistoryResponse incomeResponse(String title, long amount, Category category) {
+        return TransactionHistoryResponse.builder()
+                .transactionId(TRANSACTION_ID)
+                .title(title)
+                .transactionDate(LocalDate.of(2026, 8, 25))
+                .transactionTime(LocalTime.of(9, 30))
+                .amount(amount)
+                .type(Transaction.TransactionType.INCOME)
+                .category(category)
+                .categoryName(category.getDisplayName())
+                .build();
+    }
+
+    private TransactionHistoryResponse expenseResponse(String title, long amount, Category category) {
+        return TransactionHistoryResponse.builder()
+                .transactionId(TRANSACTION_ID)
+                .title(title)
+                .transactionDate(LocalDate.of(2026, 8, 12))
+                .transactionTime(LocalTime.of(14, 30))
+                .amount(amount)
+                .type(Transaction.TransactionType.EXPENSE)
+                .category(category)
+                .categoryName(category.getDisplayName())
+                .build();
     }
 }


### PR DESCRIPTION
## 작업 내용

  거래 내역 관리 API를 추가했습니다.

  ### 추가된 API

  - `GET /transactions/recent`
    - 현재 로그인 사용자의 최근 거래 내역 조회
    - `limit` 파라미터로 조회 개수 지정 가능

  - `POST /transactions`
    - 수입/지출 거래 내역 직접 추가
    - 성공 시 `201 Created` 반환
    - 응답 바디 없음

  - `DELETE /transactions/{transactionId}`
    - 본인 거래 내역 삭제
    - 성공 시 `204 No Content` 반환

  - `PATCH /transactions/{transactionId}/category`
    - 본인 거래 내역의 카테고리 변경

  ## 구현 상세

  - 거래 관리 기능을 SRP에 맞춰 서비스별로 분리
    - `GetRecentTransactionListService`
    - `CreateTransactionService`
    - `DeleteTransactionService`
    - `UpdateTransactionCategoryService`

  - 현재 로그인 사용자는 기존 `UserFacade`를 통해 조회
    - 클라이언트가 `userId`를 넘기지 않음
    - JWT 기반 현재 사용자 기준으로 거래 내역 조회/수정/삭제

  - Querydsl 기반 최근 거래 조회 쿼리 추가
    - `findRecentTransactionHistories`
    - 거래일, 생성일, ID 기준 최신순 정렬

  - 거래 소유자 검증 추가
    - `findByIdAndUser_Id`
    - 본인 거래가 아닌 경우 `TRANSACTION_NOT_FOUND` 처리

  - 거래 응답 필드 확장
    - `transactionId`
    - `type`
    - `category`
    - `categoryName`
    - 거래 날짜/시간 포맷 유지

  - Swagger 문서 추가
    - `TransactionApiDocument`에 신규 API 명세 반영
    - Controller에는 Swagger 어노테이션을 직접 작성하지 않는 기존 컨벤션 유지

  - 전역 예외 처리 보강
    - `TRANSACTION_NOT_FOUND`
    - `INVALID_REQUEST`
    - 요청 검증 실패, 타입 불일치, 누락 파라미터 처리

  - 최근 거래 조회 성능을 위한 인덱스 추가
    - `idx_transaction_user_date`

  ## 테스트

  `TransactionControllerTest`를 확장하여 신규 API 응답 계약을 검증했습니다.

  검증 항목:

  - 최근 거래 내역 조회
  - 거래 내역 추가
  - 잘못된 거래 추가 요청 시 `400 Bad Request`
  - 거래 내역 삭제
  - 거래 카테고리 변경
  - 기존 월별 수입/지출 내역 조회 응답 유지


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 최근 거래 내역 조회 기능 추가 (최근순, 개수 제한 가능)
  * 거래 내역 생성 기능 추가
  * 거래 내역 삭제 기능 추가
  * 거래 카테고리 수정 기능 추가

* **Bug Fixes**
  * 잘못된 요청에 대한 에러 처리 개선
  * 거래 내역을 찾을 수 없는 경우 에러 메시지 개선

* **Performance**
  * 거래 내역 조회 성능 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->