### PR TITLE
feat(#20): MCP 금융 데이터 연동 및 Hermes 이벤트 전송 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Hermes local webhook (keep the actual secret only in untracked .env or deployment secrets)
+HERMES_WEBHOOK_URL=http://127.0.0.1:8644/webhooks/bankramen-transactions
+HERMES_WEBHOOK_SECRET=replace-with-hermes-subscription-secret
+
+# Bankramen MCP account link. Keep the actual bearer token only in untracked .env or deployment secrets.
+MCP_CONNECTION_ID=hermes-local
+MCP_CONSUMER_ID=hermes-agent
+MCP_LINKED_USER_ID=replace-with-existing-bankramen-user-uuid
+MCP_ENABLED=true
+MCP_INITIAL_TOKEN=replace-with-a-long-random-mcp-bearer-token

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,9 @@ out/
 ### VS Code ###
 .vscode/
 .omx/
+.omo/
 ### Local secrets / OS files ###
+.env
 .DS_Store
 **/.DS_Store
 src/main/resources/config/*.json

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,9 @@ dependencies {
 
     // ETC
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+
+    // MCP
+    implementation 'io.modelcontextprotocol.sdk:mcp-json-jackson2:1.1.2'
 }
 
 dependencyManagement {

--- a/src/main/java/org/example/bankramenserver/domain/push/presentation/dto/PushNotificationResponse.java
+++ b/src/main/java/org/example/bankramenserver/domain/push/presentation/dto/PushNotificationResponse.java
@@ -120,10 +120,14 @@ public record PushNotificationResponse(
 
         private static String iconBackgroundColor(PushNotification.NotificationType type) {
             return switch (type) {
-                case RECURRING_ALERT -> "#EAF3FF";
+                case RECURRING_ALERT,
+                     PAYMENT_RECORDED,
+                     RECURRING_CANDIDATE,
+                     RECURRING_PAYMENT_REMINDER,
+                     RECURRING_PAYMENT_CONFIRMED,
+                     RECURRING_PAYMENT_MISSING -> "#EAF3FF";
                 case MONTHLY_REPORT -> "#FDF0F2";
                 case PATTERN_DETECTED -> "#FFE943";
-                case PAYMENT_RECORDED -> "#EAF3FF";
             };
         }
     }

--- a/src/main/java/org/example/bankramenserver/domain/report/service/GetMonthlyAmountSummaryService.java
+++ b/src/main/java/org/example/bankramenserver/domain/report/service/GetMonthlyAmountSummaryService.java
@@ -22,13 +22,16 @@ public class GetMonthlyAmountSummaryService {
 
     @Transactional(readOnly = true)
     public MonthlyAmountSummaryResponse execute(int year, int month) {
-        UUID currentUserId = userFacade.getCurrentUser().getId();
+        return execute(userFacade.getCurrentUser().getId(), year, month);
+    }
 
+    @Transactional(readOnly = true)
+    public MonthlyAmountSummaryResponse execute(UUID userId, int year, int month) {
         YearMonth currentMonth = YearMonth.of(year, month);
         YearMonth previousMonth = currentMonth.minusMonths(1);
 
         AmountSummaryRow amountSummary = monthlyReportRepository.findAmountSummary(
-                currentUserId,
+                userId,
                 currentMonth.atDay(1),
                 currentMonth.atEndOfMonth(),
                 previousMonth.atDay(1),

--- a/src/main/java/org/example/bankramenserver/domain/report/service/GetMonthlyCategoryExpenseListService.java
+++ b/src/main/java/org/example/bankramenserver/domain/report/service/GetMonthlyCategoryExpenseListService.java
@@ -23,13 +23,16 @@ public class GetMonthlyCategoryExpenseListService {
 
     @Transactional(readOnly = true)
     public MonthlyCategoryExpenseListResponse execute(int year, int month) {
-        UUID currentUserId = userFacade.getCurrentUser().getId();
+        return execute(userFacade.getCurrentUser().getId(), year, month);
+    }
 
+    @Transactional(readOnly = true)
+    public MonthlyCategoryExpenseListResponse execute(UUID userId, int year, int month) {
         YearMonth currentMonth = YearMonth.of(year, month);
         YearMonth previousMonth = currentMonth.minusMonths(1);
 
         List<CategoryExpenseRow> rows = monthlyReportRepository.findCategoryExpenseComparisons(
-                currentUserId,
+                userId,
                 currentMonth.atDay(1),
                 currentMonth.atEndOfMonth(),
                 previousMonth.atDay(1),

--- a/src/main/java/org/example/bankramenserver/domain/transaction/event/PaymentTransactionRecordedEvent.java
+++ b/src/main/java/org/example/bankramenserver/domain/transaction/event/PaymentTransactionRecordedEvent.java
@@ -2,6 +2,7 @@ package org.example.bankramenserver.domain.transaction.event;
 
 import org.example.bankramenserver.domain.category.domain.Category;
 
+import java.time.LocalDate;
 import java.util.UUID;
 
 public record PaymentTransactionRecordedEvent(
@@ -9,6 +10,7 @@ public record PaymentTransactionRecordedEvent(
         UUID transactionId,
         String title,
         Long amount,
-        Category category
+        Category category,
+        LocalDate occurredAt
 ) {
 }

--- a/src/main/java/org/example/bankramenserver/domain/transaction/service/CreatePaymentNotificationTransactionService.java
+++ b/src/main/java/org/example/bankramenserver/domain/transaction/service/CreatePaymentNotificationTransactionService.java
@@ -52,7 +52,8 @@ public class CreatePaymentNotificationTransactionService {
                 transaction.getId(),
                 transaction.getDescription(),
                 transaction.getAmount(),
-                transaction.getCategory()
+                transaction.getCategory(),
+                transaction.getTransactionDate()
         ));
     }
 }

--- a/src/main/java/org/example/bankramenserver/domain/transaction/service/GetRecentTransactionListService.java
+++ b/src/main/java/org/example/bankramenserver/domain/transaction/service/GetRecentTransactionListService.java
@@ -19,10 +19,13 @@ public class GetRecentTransactionListService {
 
     @Transactional(readOnly = true)
     public RecentTransactionListResponse execute(int limit) {
-        UUID currentUserId = userFacade.getCurrentUser().getId();
+        return execute(userFacade.getCurrentUser().getId(), limit);
+    }
 
+    @Transactional(readOnly = true)
+    public RecentTransactionListResponse execute(UUID userId, int limit) {
         return RecentTransactionListResponse.from(
-                transactionRepository.findRecentTransactionHistories(currentUserId, limit)
+                transactionRepository.findRecentTransactionHistories(userId, limit)
                         .stream()
                         .map(TransactionHistoryResponse::from)
                         .toList()

--- a/src/main/java/org/example/bankramenserver/global/config/SecurityConfig.java
+++ b/src/main/java/org/example/bankramenserver/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package org.example.bankramenserver.global.config;
 import lombok.RequiredArgsConstructor;
 import org.example.bankramenserver.global.error.GlobalExceptionFilter;
 import org.example.bankramenserver.global.jwt.JwtAuthenticationFilter;
+import org.example.bankramenserver.infrastructure.mcp.auth.McpBearerAuthenticationFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
@@ -21,6 +22,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final McpBearerAuthenticationFilter mcpBearerAuthenticationFilter;
     private final GlobalExceptionFilter globalExceptionFilter;
 
     @Bean
@@ -62,6 +64,7 @@ public class SecurityConfig {
                                 "/categories/**",
                                 "/push-notifications/**"
                         ).authenticated()
+                        .requestMatchers("/mcp").authenticated()
                         .anyRequest().authenticated()
                 )
                 .formLogin(AbstractHttpConfigurer::disable)
@@ -70,8 +73,11 @@ public class SecurityConfig {
                 .addFilterBefore(jwtAuthenticationFilter,
                         UsernamePasswordAuthenticationFilter.class)
 
+                .addFilterBefore(mcpBearerAuthenticationFilter,
+                        JwtAuthenticationFilter.class)
+
                 .addFilterBefore(globalExceptionFilter,
-                        JwtAuthenticationFilter.class);
+                        McpBearerAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/org/example/bankramenserver/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/org/example/bankramenserver/global/jwt/JwtAuthenticationFilter.java
@@ -35,6 +35,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
 
+        if ("/mcp".equals(path)) {
+            return true;
+        }
+
         for (String permit : PERMIT_URLS) {
             if (path.startsWith(permit)) {
                 return true;

--- a/src/main/java/org/example/bankramenserver/infrastructure/integration/HermesWebhookConnector.java
+++ b/src/main/java/org/example/bankramenserver/infrastructure/integration/HermesWebhookConnector.java
@@ -1,0 +1,62 @@
+package org.example.bankramenserver.infrastructure.integration;
+
+import lombok.extern.slf4j.Slf4j;
+import org.example.bankramenserver.infrastructure.integration.domain.IntegrationConnectionProperties;
+import org.example.bankramenserver.infrastructure.integration.domain.IntegrationOutbox;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.HexFormat;
+
+@Slf4j
+@Component
+public class HermesWebhookConnector implements IntegrationConnector {
+
+    private static final String CONNECTOR_TYPE = "HERMES_WEBHOOK";
+    private final HttpClient httpClient;
+
+    public HermesWebhookConnector() {
+        this(HttpClient.newHttpClient());
+    }
+
+    HermesWebhookConnector(HttpClient httpClient) {
+        this.httpClient = httpClient;
+    }
+
+    @Override
+    public String connectorType() {
+        return CONNECTOR_TYPE;
+    }
+
+    @Override
+    public void dispatch(IntegrationOutbox outbox, IntegrationConnectionProperties.Connection connection)
+            throws IOException, InterruptedException {
+        byte[] body = outbox.getPayload().getBytes(StandardCharsets.UTF_8);
+        HttpResponse<Void> response = httpClient.send(HttpRequest.newBuilder(URI.create(connection.webhookUrl()))
+                        .header("Content-Type", "application/json")
+                        .header("X-Hub-Signature-256", signature(body, connection.secret()))
+                        .header("X-Request-ID", outbox.getEventId())
+                        .POST(HttpRequest.BodyPublishers.ofByteArray(body))
+                        .build(), HttpResponse.BodyHandlers.discarding());
+        if (response.statusCode() >= 400) {
+            throw new IOException("Webhook returned HTTP " + response.statusCode());
+        }
+    }
+
+    static String signature(byte[] body, String secret) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+            return "sha256=" + HexFormat.of().formatHex(mac.doFinal(body));
+        } catch (Exception exception) {
+            throw new IllegalStateException("Could not sign Hermes webhook payload", exception);
+        }
+    }
+}

--- a/src/main/java/org/example/bankramenserver/infrastructure/integration/IntegrationConnector.java
+++ b/src/main/java/org/example/bankramenserver/infrastructure/integration/IntegrationConnector.java
@@ -1,0 +1,11 @@
+package org.example.bankramenserver.infrastructure.integration;
+
+import org.example.bankramenserver.infrastructure.integration.domain.IntegrationConnectionProperties;
+import org.example.bankramenserver.infrastructure.integration.domain.IntegrationOutbox;
+
+public interface IntegrationConnector {
+
+    String connectorType();
+
+    void dispatch(IntegrationOutbox outbox, IntegrationConnectionProperties.Connection connection) throws Exception;
+}

--- a/src/main/java/org/example/bankramenserver/infrastructure/integration/IntegrationOutboxDispatcher.java
+++ b/src/main/java/org/example/bankramenserver/infrastructure/integration/IntegrationOutboxDispatcher.java
@@ -1,0 +1,53 @@
+package org.example.bankramenserver.infrastructure.integration;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.example.bankramenserver.infrastructure.integration.domain.IntegrationConnectionProperties;
+import org.example.bankramenserver.infrastructure.integration.domain.IntegrationOutbox;
+import org.example.bankramenserver.infrastructure.integration.domain.IntegrationOutboxRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class IntegrationOutboxDispatcher {
+
+    private final IntegrationOutboxRepository outboxRepository;
+    private final IntegrationConnectionProperties connectionProperties;
+    private final List<IntegrationConnector> connectors;
+
+    @Transactional
+    public void dispatchDue() {
+        LocalDateTime now = LocalDateTime.now();
+        outboxRepository.findTop50ByStatusInOrderByCreatedAtAsc(List.of(
+                        IntegrationOutbox.Status.PENDING,
+                        IntegrationOutbox.Status.RETRYING
+                )).stream()
+                .filter(outbox -> outbox.getNextAttemptAt() == null || !outbox.getNextAttemptAt().isAfter(now))
+                .forEach(this::dispatch);
+    }
+
+    private void dispatch(IntegrationOutbox outbox) {
+        try {
+            IntegrationConnectionProperties.Connection connection = connectionProperties
+                    .findByConnectionId(outbox.getConnectionId())
+                    .orElseThrow(() -> new IllegalStateException("Integration connection is unavailable"));
+            if (!connection.enabled()) {
+                throw new IllegalStateException("Integration connection is disabled");
+            }
+            connectors.stream()
+                    .filter(connector -> connector.connectorType().equals(outbox.getConnectorType()))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalStateException("Integration connector is unavailable"))
+                    .dispatch(outbox, connection);
+            outbox.markDelivered();
+        } catch (Exception exception) {
+            outbox.markForRetry(exception);
+            log.warn("Integration delivery failed: outboxId={}, connectionId={}", outbox.getId(), outbox.getConnectionId(), exception);
+        }
+    }
+}

--- a/src/main/java/org/example/bankramenserver/infrastructure/integration/IntegrationOutboxEventListener.java
+++ b/src/main/java/org/example/bankramenserver/infrastructure/integration/IntegrationOutboxEventListener.java
@@ -1,0 +1,28 @@
+package org.example.bankramenserver.infrastructure.integration;
+
+import lombok.RequiredArgsConstructor;
+import org.example.bankramenserver.domain.transaction.event.PaymentTransactionRecordedEvent;
+import org.example.bankramenserver.infrastructure.fcm.FcmAsyncConfig;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class IntegrationOutboxEventListener {
+
+    private final IntegrationOutboxWriter outboxWriter;
+    private final IntegrationOutboxDispatcher outboxDispatcher;
+
+    @TransactionalEventListener(phase = TransactionPhase.BEFORE_COMMIT)
+    public void record(PaymentTransactionRecordedEvent event) {
+        outboxWriter.record(event);
+    }
+
+    @Async(FcmAsyncConfig.FCM_PUSH_TASK_EXECUTOR)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void dispatch(PaymentTransactionRecordedEvent event) {
+        outboxDispatcher.dispatchDue();
+    }
+}

--- a/src/main/java/org/example/bankramenserver/infrastructure/integration/IntegrationOutboxScheduler.java
+++ b/src/main/java/org/example/bankramenserver/infrastructure/integration/IntegrationOutboxScheduler.java
@@ -1,0 +1,17 @@
+package org.example.bankramenserver.infrastructure.integration;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class IntegrationOutboxScheduler {
+
+    private final IntegrationOutboxDispatcher outboxDispatcher;
+
+    @Scheduled(fixedDelayString = "${integration.dispatch-interval-ms:30000}")
+    public void dispatchDue() {
+        outboxDispatcher.dispatchDue();
+    }
+}

--- a/src/main/java/org/example/bankramenserver/infrastructure/integration/IntegrationOutboxWriter.java
+++ b/src/main/java/org/example/bankramenserver/infrastructure/integration/IntegrationOutboxWriter.java
@@ -1,0 +1,64 @@
+package org.example.bankramenserver.infrastructure.integration;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.example.bankramenserver.domain.transaction.event.PaymentTransactionRecordedEvent;
+import org.example.bankramenserver.infrastructure.integration.domain.IntegrationConnectionProperties;
+import org.example.bankramenserver.infrastructure.integration.domain.IntegrationOutbox;
+import org.example.bankramenserver.infrastructure.integration.domain.IntegrationOutboxRepository;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class IntegrationOutboxWriter {
+
+    public static final String TRANSACTION_CREATED = "transaction.created";
+
+    private final IntegrationOutboxRepository outboxRepository;
+    private final IntegrationConnectionProperties connectionProperties;
+    private final ObjectMapper objectMapper;
+
+    public void record(PaymentTransactionRecordedEvent event) {
+        String payload = serialize(event);
+        connectionProperties.getConnections().stream()
+                .filter(connection -> connection.subscribesTo(TRANSACTION_CREATED))
+                .forEach(connection -> outboxRepository.save(IntegrationOutbox.pending(
+                        event.transactionId().toString(),
+                        connection.connectionId(),
+                        connection.connectorType(),
+                        TRANSACTION_CREATED,
+                        payload
+                )));
+    }
+
+    private String serialize(PaymentTransactionRecordedEvent event) {
+        try {
+            return objectMapper.writeValueAsString(new TransactionCreatedPayload(
+                    event.transactionId().toString(),
+                    TRANSACTION_CREATED,
+                    event.userId().toString(),
+                    new TransactionPayload(
+                            event.transactionId().toString(),
+                            event.title(),
+                            event.amount(),
+                            event.category().getDisplayName(),
+                            event.occurredAt().toString()
+                    )
+            ));
+        } catch (JsonProcessingException exception) {
+            throw new IllegalStateException("Could not serialize integration event", exception);
+        }
+    }
+
+    private record TransactionCreatedPayload(
+            String eventId,
+            @com.fasterxml.jackson.annotation.JsonProperty("event_type") String eventType,
+            String userId,
+            TransactionPayload transaction
+    ) {
+    }
+
+    private record TransactionPayload(String id, String title, Long amount, String category, String occurredAt) {
+    }
+}

--- a/src/main/java/org/example/bankramenserver/infrastructure/integration/domain/IntegrationConnectionProperties.java
+++ b/src/main/java/org/example/bankramenserver/infrastructure/integration/domain/IntegrationConnectionProperties.java
@@ -1,0 +1,38 @@
+package org.example.bankramenserver.infrastructure.integration.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "integration")
+public class IntegrationConnectionProperties {
+
+    private List<Connection> connections = List.of();
+
+    public Optional<Connection> findByConnectionId(String connectionId) {
+        return connections.stream().filter(connection -> connection.connectionId().equals(connectionId)).findFirst();
+    }
+
+    public record Connection(
+            String connectionId,
+            String consumerId,
+            String connectorType,
+            boolean enabled,
+            List<String> subscribedEvents,
+            String webhookUrl,
+            String secret
+    ) {
+        public boolean subscribesTo(String eventType) {
+            return enabled && StringUtils.hasText(webhookUrl) && StringUtils.hasText(secret)
+                    && subscribedEvents.contains(eventType);
+        }
+    }
+}

--- a/src/main/java/org/example/bankramenserver/infrastructure/integration/domain/IntegrationOutbox.java
+++ b/src/main/java/org/example/bankramenserver/infrastructure/integration/domain/IntegrationOutbox.java
@@ -1,0 +1,101 @@
+package org.example.bankramenserver.infrastructure.integration.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.example.bankramenserver.global.common.BaseEntity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Entity
+@Table(name = "integration_outbox", uniqueConstraints = @UniqueConstraint(
+        name = "uk_integration_outbox_event_connection", columnNames = {"event_id", "connection_id"}
+))
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class IntegrationOutbox extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID id;
+
+    @Column(name = "event_id", nullable = false, updatable = false)
+    private String eventId;
+
+    @Column(name = "connection_id", nullable = false, updatable = false)
+    private String connectionId;
+
+    @Column(name = "connector_type", nullable = false, updatable = false)
+    private String connectorType;
+
+    @Column(name = "event_type", nullable = false, updatable = false)
+    private String eventType;
+
+    @Lob
+    @Column(name = "payload", nullable = false, columnDefinition = "TEXT")
+    private String payload;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private Status status;
+
+    @Column(name = "attempt_count", nullable = false)
+    private int attemptCount;
+
+    @Column(name = "next_attempt_at")
+    private LocalDateTime nextAttemptAt;
+
+    @Column(name = "last_error", columnDefinition = "TEXT")
+    private String lastError;
+
+    @Column(name = "delivered_at")
+    private LocalDateTime deliveredAt;
+
+    private IntegrationOutbox(String eventId, String connectionId, String connectorType, String eventType, String payload) {
+        this.eventId = eventId;
+        this.connectionId = connectionId;
+        this.connectorType = connectorType;
+        this.eventType = eventType;
+        this.payload = payload;
+        this.status = Status.PENDING;
+        this.attemptCount = 0;
+    }
+
+    public static IntegrationOutbox pending(String eventId, String connectionId, String connectorType, String eventType, String payload) {
+        return new IntegrationOutbox(eventId, connectionId, connectorType, eventType, payload);
+    }
+
+    public boolean isPending() {
+        return status == Status.PENDING || status == Status.RETRYING;
+    }
+
+    public void markDelivered() {
+        status = Status.DELIVERED;
+        deliveredAt = LocalDateTime.now();
+        nextAttemptAt = null;
+        lastError = null;
+    }
+
+    public void markForRetry(Exception exception) {
+        attemptCount++;
+        status = Status.RETRYING;
+        nextAttemptAt = LocalDateTime.now().plusMinutes(Math.min(1L << Math.min(attemptCount, 6), 60));
+        lastError = exception.getClass().getSimpleName() + ": " + exception.getMessage();
+    }
+
+    public enum Status {
+        PENDING, RETRYING, DELIVERED
+    }
+}

--- a/src/main/java/org/example/bankramenserver/infrastructure/integration/domain/IntegrationOutboxRepository.java
+++ b/src/main/java/org/example/bankramenserver/infrastructure/integration/domain/IntegrationOutboxRepository.java
@@ -1,0 +1,12 @@
+package org.example.bankramenserver.infrastructure.integration.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public interface IntegrationOutboxRepository extends JpaRepository<IntegrationOutbox, UUID> {
+
+    List<IntegrationOutbox> findTop50ByStatusInOrderByCreatedAtAsc(List<IntegrationOutbox.Status> statuses);
+}

--- a/src/main/java/org/example/bankramenserver/infrastructure/mcp/McpFinancialTools.java
+++ b/src/main/java/org/example/bankramenserver/infrastructure/mcp/McpFinancialTools.java
@@ -1,0 +1,138 @@
+package org.example.bankramenserver.infrastructure.mcp;
+
+import lombok.RequiredArgsConstructor;
+import org.example.bankramenserver.domain.report.presentation.dto.MonthlyAmountSummaryResponse;
+import org.example.bankramenserver.domain.report.presentation.dto.MonthlyCategoryExpenseListResponse;
+import org.example.bankramenserver.domain.report.service.GetMonthlyAmountSummaryService;
+import org.example.bankramenserver.domain.report.service.GetMonthlyCategoryExpenseListService;
+import org.example.bankramenserver.domain.transaction.presentation.dto.TransactionHistoryResponse;
+import org.example.bankramenserver.domain.transaction.service.GetRecentTransactionListService;
+import org.example.bankramenserver.infrastructure.mcp.auth.AgentScope;
+import org.example.bankramenserver.infrastructure.mcp.auth.McpAgentPrincipal;
+import org.example.bankramenserver.infrastructure.mcp.auth.McpAgentPrincipalResolver;
+import org.example.bankramenserver.infrastructure.mcp.auth.McpScopeDeniedException;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+@Service
+@RequiredArgsConstructor
+public class McpFinancialTools {
+
+    private final McpAgentPrincipalResolver principalResolver;
+    private final GetRecentTransactionListService getRecentTransactionListService;
+    private final GetMonthlyAmountSummaryService getMonthlyAmountSummaryService;
+    private final GetMonthlyCategoryExpenseListService getMonthlyCategoryExpenseListService;
+
+    public Map<String, Object> getRecentTransactions(Map<String, Object> arguments) {
+        return execute(() -> {
+            int limit = requiredInt(arguments, "limit", 1, 50);
+            McpAgentPrincipal principal = principalResolver.requireScope(AgentScope.TRANSACTIONS_READ);
+            List<Map<String, Object>> transactions = getRecentTransactionListService
+                    .execute(principal.linkedUserId(), limit)
+                    .transactions()
+                    .stream()
+                    .map(this::transaction)
+                    .toList();
+            return Map.of("transactions", transactions);
+        });
+    }
+
+    public Map<String, Object> getMonthlyExpenseSummary(Map<String, Object> arguments) {
+        return execute(() -> {
+            int year = requiredInt(arguments, "year", 2000, 2100);
+            int month = requiredInt(arguments, "month", 1, 12);
+            McpAgentPrincipal principal = principalResolver.requireScope(AgentScope.REPORTS_READ);
+            MonthlyAmountSummaryResponse summary = getMonthlyAmountSummaryService
+                    .execute(principal.linkedUserId(), year, month);
+            return Map.of("yearMonth", summary.yearMonth(), "expense", amountComparison(summary.expense()));
+        });
+    }
+
+    public Map<String, Object> getCategoryExpenses(Map<String, Object> arguments) {
+        return execute(() -> {
+            int year = requiredInt(arguments, "year", 2000, 2100);
+            int month = requiredInt(arguments, "month", 1, 12);
+            McpAgentPrincipal principal = principalResolver.requireScope(AgentScope.REPORTS_READ);
+            MonthlyCategoryExpenseListResponse response = getMonthlyCategoryExpenseListService
+                    .execute(principal.linkedUserId(), year, month);
+            return Map.of(
+                    "yearMonth", response.yearMonth(),
+                    "totalExpense", response.totalExpense(),
+                    "categories", response.categories().stream().map(category -> Map.<String, Object>of(
+                            "category", category.category().name(),
+                            "categoryName", category.categoryName(),
+                            "expenseAmount", category.expenseAmount(),
+                            "expenseRatio", category.expenseRatio(),
+                            "spentMoreThanPreviousMonth", category.spentMoreThanPreviousMonth()
+                    )).toList()
+            );
+        });
+    }
+
+    public Map<String, Object> getMonthlyIncomeExpenseSummary(Map<String, Object> arguments) {
+        return execute(() -> {
+            int year = requiredInt(arguments, "year", 2000, 2100);
+            int month = requiredInt(arguments, "month", 1, 12);
+            McpAgentPrincipal principal = principalResolver.requireScope(AgentScope.REPORTS_READ);
+            MonthlyAmountSummaryResponse summary = getMonthlyAmountSummaryService
+                    .execute(principal.linkedUserId(), year, month);
+            return Map.of(
+                    "yearMonth", summary.yearMonth(),
+                    "expense", amountComparison(summary.expense()),
+                    "income", amountComparison(summary.income())
+            );
+        });
+    }
+
+    private Map<String, Object> transaction(TransactionHistoryResponse response) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("transactionId", response.transactionId().toString());
+        result.put("title", response.title());
+        result.put("amount", response.amount());
+        result.put("category", response.category().name());
+        result.put("type", response.type().name());
+        result.put("transactionDate", response.transactionDate().toString());
+        return result;
+    }
+
+    private Map<String, Object> amountComparison(MonthlyAmountSummaryResponse.AmountComparison comparison) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("currentAmount", comparison.currentAmount());
+        result.put("previousAmount", comparison.previousAmount());
+        result.put("hasPreviousMonthData", comparison.hasPreviousMonthData());
+        result.put("differenceRate", comparison.differenceRate());
+        return result;
+    }
+
+    private Map<String, Object> execute(Supplier<Map<String, Object>> query) {
+        try {
+            return query.get();
+        } catch (McpInvalidArgumentException exception) {
+            return Map.of("error", exception.getMessage());
+        } catch (McpScopeDeniedException exception) {
+            return Map.of("error", "missing required MCP scope");
+        }
+    }
+
+    private int requiredInt(Map<String, Object> arguments, String name, int minimum, int maximum) {
+        Object value = arguments.get(name);
+        if (!(value instanceof Number number)
+                || number.doubleValue() != Math.rint(number.doubleValue())
+                || number.longValue() < minimum
+                || number.longValue() > maximum) {
+            throw new McpInvalidArgumentException(name + " must be between " + minimum + " and " + maximum);
+        }
+        return number.intValue();
+    }
+
+    private static class McpInvalidArgumentException extends RuntimeException {
+
+        private McpInvalidArgumentException(String message) {
+            super(message);
+        }
+    }
+}

--- a/src/main/java/org/example/bankramenserver/infrastructure/mcp/McpServerConfiguration.java
+++ b/src/main/java/org/example/bankramenserver/infrastructure/mcp/McpServerConfiguration.java
@@ -1,0 +1,116 @@
+package org.example.bankramenserver.infrastructure.mcp;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.jackson2.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpServerFeatures;
+import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
+import io.modelcontextprotocol.spec.McpSchema;
+import jakarta.servlet.Servlet;
+import lombok.RequiredArgsConstructor;
+import org.example.bankramenserver.infrastructure.mcp.auth.McpInitialConnectionProperties;
+import org.springframework.boot.web.servlet.ServletRegistrationBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableConfigurationProperties(McpInitialConnectionProperties.class)
+public class McpServerConfiguration {
+
+    private final McpFinancialTools financialTools;
+    private final ObjectMapper objectMapper;
+
+    @Bean
+    public McpJsonMapper mcpJsonMapper() {
+        return new JacksonMcpJsonMapper(objectMapper);
+    }
+
+    @Bean
+    public HttpServletStreamableServerTransportProvider mcpTransport() {
+        return HttpServletStreamableServerTransportProvider.builder()
+                .jsonMapper(mcpJsonMapper())
+                .mcpEndpoint("/mcp")
+                .disallowDelete(true)
+                .build();
+    }
+
+    @Bean
+    public ServletRegistrationBean<Servlet> mcpServlet(HttpServletStreamableServerTransportProvider transport) {
+        return new ServletRegistrationBean<>(transport, "/mcp");
+    }
+
+    @Bean
+    public McpSyncServer mcpServer(HttpServletStreamableServerTransportProvider transport) {
+        return McpServer.sync(transport)
+                .serverInfo("bankramen", "1.0.0")
+                .tools(List.of(
+                        tool("get_recent_transactions", "Get the linked user's most recent transactions. Use this for a recent activity list.",
+                                schema(Map.of("limit", integerProperty("Maximum transactions to return, from 1 to 50.")), List.of("limit")),
+                                financialTools::getRecentTransactions),
+                        tool("get_monthly_expense_summary", "Get the linked user's expense total for a month and its comparison with the previous month.",
+                                yearMonthSchema(), financialTools::getMonthlyExpenseSummary),
+                        tool("get_category_expenses", "Get the linked user's expense totals grouped by category for a month.",
+                                yearMonthSchema(), financialTools::getCategoryExpenses),
+                        tool("get_monthly_income_expense_summary", "Get the linked user's income and expense totals for a month and their comparisons with the previous month.",
+                                yearMonthSchema(), financialTools::getMonthlyIncomeExpenseSummary)
+                ))
+                .build();
+    }
+
+    private McpServerFeatures.SyncToolSpecification tool(
+            String name,
+            String description,
+            McpSchema.JsonSchema inputSchema,
+            Function<Map<String, Object>, Map<String, Object>> handler
+    ) {
+        McpSchema.Tool tool = McpSchema.Tool.builder()
+                .name(name)
+                .description(description)
+                .inputSchema(inputSchema)
+                .build();
+        return new McpServerFeatures.SyncToolSpecification(tool, (exchange, request) -> response(handler.apply(request.arguments())));
+    }
+
+    private McpSchema.JsonSchema yearMonthSchema() {
+        return schema(Map.of(
+                "year", yearProperty(),
+                "month", Map.of("type", "integer", "minimum", 1, "maximum", 12, "description", "Calendar month from 1 to 12.")
+        ), List.of("year", "month"));
+    }
+
+    private McpSchema.JsonSchema schema(Map<String, Object> properties, List<String> required) {
+        return new McpSchema.JsonSchema("object", properties, required, false, null, null);
+    }
+
+    private Map<String, Object> integerProperty(String description) {
+        return Map.of("type", "integer", "minimum", 1, "maximum", 50, "description", description);
+    }
+
+    private Map<String, Object> yearProperty() {
+        return Map.of("type", "integer", "minimum", 2000, "maximum", 2100, "description", "Calendar year from 2000 to 2100.");
+    }
+
+    private McpSchema.CallToolResult response(Map<String, Object> result) {
+        try {
+            return McpSchema.CallToolResult.builder()
+                    .addTextContent(objectMapper.writeValueAsString(result))
+                    .structuredContent(result)
+                    .isError(result.containsKey("error"))
+                    .build();
+        } catch (JsonProcessingException exception) {
+            return McpSchema.CallToolResult.builder()
+                    .addTextContent("Unable to serialize MCP tool result")
+                    .isError(true)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/org/example/bankramenserver/infrastructure/mcp/auth/AgentConnection.java
+++ b/src/main/java/org/example/bankramenserver/infrastructure/mcp/auth/AgentConnection.java
@@ -1,0 +1,89 @@
+package org.example.bankramenserver.infrastructure.mcp.auth;
+
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.EnumSet;
+import java.util.Set;
+import java.util.UUID;
+
+@Entity
+@Getter
+@Table(name = "agent_connections")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AgentConnection {
+
+    @Id
+    @Column(name = "connection_id", nullable = false, updatable = false)
+    private String connectionId;
+
+    @Column(name = "consumer_id", nullable = false)
+    private String consumerId;
+
+    @Column(name = "linked_user_id", nullable = false)
+    private UUID linkedUserId;
+
+    @Column(nullable = false)
+    private boolean enabled;
+
+    @Column(name = "token_hash", nullable = false, unique = true, length = 64)
+    private String tokenHash;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @Enumerated(EnumType.STRING)
+    @CollectionTable(name = "agent_connection_scopes", joinColumns = @JoinColumn(name = "connection_id"))
+    @Column(name = "scope", nullable = false)
+    private Set<AgentScope> scopes = EnumSet.noneOf(AgentScope.class);
+
+    private AgentConnection(
+            String connectionId,
+            String consumerId,
+            UUID linkedUserId,
+            boolean enabled,
+            String tokenHash,
+            Set<AgentScope> scopes
+    ) {
+        this.connectionId = connectionId;
+        this.consumerId = consumerId;
+        this.linkedUserId = linkedUserId;
+        this.enabled = enabled;
+        this.tokenHash = tokenHash;
+        this.scopes = scopes.isEmpty() ? EnumSet.noneOf(AgentScope.class) : EnumSet.copyOf(scopes);
+    }
+
+    public static AgentConnection of(
+            String connectionId,
+            String consumerId,
+            UUID linkedUserId,
+            boolean enabled,
+            String tokenHash,
+            Set<AgentScope> scopes
+    ) {
+        return new AgentConnection(connectionId, consumerId, linkedUserId, enabled, tokenHash, scopes);
+    }
+
+    public void syncInitialConnection(
+            String consumerId,
+            UUID linkedUserId,
+            boolean enabled,
+            String tokenHash
+    ) {
+        this.consumerId = consumerId;
+        this.linkedUserId = linkedUserId;
+        this.enabled = enabled;
+        this.tokenHash = tokenHash;
+        this.scopes = EnumSet.of(AgentScope.TRANSACTIONS_READ, AgentScope.REPORTS_READ);
+    }
+
+}

--- a/src/main/java/org/example/bankramenserver/infrastructure/mcp/auth/AgentConnectionRepository.java
+++ b/src/main/java/org/example/bankramenserver/infrastructure/mcp/auth/AgentConnectionRepository.java
@@ -1,0 +1,10 @@
+package org.example.bankramenserver.infrastructure.mcp.auth;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface AgentConnectionRepository extends JpaRepository<AgentConnection, String> {
+
+    Optional<AgentConnection> findByTokenHash(String tokenHash);
+}

--- a/src/main/java/org/example/bankramenserver/infrastructure/mcp/auth/AgentScope.java
+++ b/src/main/java/org/example/bankramenserver/infrastructure/mcp/auth/AgentScope.java
@@ -1,0 +1,7 @@
+package org.example.bankramenserver.infrastructure.mcp.auth;
+
+public enum AgentScope {
+
+    TRANSACTIONS_READ,
+    REPORTS_READ
+}

--- a/src/main/java/org/example/bankramenserver/infrastructure/mcp/auth/McpAgentConnectionAuthenticationService.java
+++ b/src/main/java/org/example/bankramenserver/infrastructure/mcp/auth/McpAgentConnectionAuthenticationService.java
@@ -1,0 +1,32 @@
+package org.example.bankramenserver.infrastructure.mcp.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.example.bankramenserver.domain.user.domain.repository.UserRepository;
+import org.example.bankramenserver.global.error.exception.ErrorCode;
+import org.example.bankramenserver.global.error.exception.GlobalException;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class McpAgentConnectionAuthenticationService {
+
+    private final AgentConnectionRepository agentConnectionRepository;
+    private final UserRepository userRepository;
+
+    public McpAgentPrincipal authenticate(String token) {
+        AgentConnection connection = agentConnectionRepository.findByTokenHash(McpTokenHasher.hash(token))
+                .filter(AgentConnection::isEnabled)
+                .filter(candidate -> candidate.getLinkedUserId() != null)
+                .filter(candidate -> userRepository.existsById(candidate.getLinkedUserId()))
+                .orElseThrow(() -> new GlobalException(ErrorCode.INVALID_TOKEN));
+
+        return new McpAgentPrincipal(
+                connection.getConnectionId(),
+                connection.getConsumerId(),
+                connection.getLinkedUserId(),
+                Set.copyOf(connection.getScopes())
+        );
+    }
+}

--- a/src/main/java/org/example/bankramenserver/infrastructure/mcp/auth/McpAgentPrincipal.java
+++ b/src/main/java/org/example/bankramenserver/infrastructure/mcp/auth/McpAgentPrincipal.java
@@ -1,0 +1,16 @@
+package org.example.bankramenserver.infrastructure.mcp.auth;
+
+import java.util.Set;
+import java.util.UUID;
+
+public record McpAgentPrincipal(
+        String connectionId,
+        String consumerId,
+        UUID linkedUserId,
+        Set<AgentScope> scopes
+) {
+
+    public boolean hasScope(AgentScope scope) {
+        return scopes.contains(scope);
+    }
+}

--- a/src/main/java/org/example/bankramenserver/infrastructure/mcp/auth/McpAgentPrincipalResolver.java
+++ b/src/main/java/org/example/bankramenserver/infrastructure/mcp/auth/McpAgentPrincipalResolver.java
@@ -1,0 +1,22 @@
+package org.example.bankramenserver.infrastructure.mcp.auth;
+
+import org.example.bankramenserver.global.error.exception.ErrorCode;
+import org.example.bankramenserver.global.error.exception.GlobalException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class McpAgentPrincipalResolver {
+
+    public McpAgentPrincipal requireScope(AgentScope scope) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !(authentication.getPrincipal() instanceof McpAgentPrincipal principal)) {
+            throw new GlobalException(ErrorCode.INVALID_TOKEN);
+        }
+        if (!principal.hasScope(scope)) {
+            throw new McpScopeDeniedException();
+        }
+        return principal;
+    }
+}

--- a/src/main/java/org/example/bankramenserver/infrastructure/mcp/auth/McpBearerAuthenticationFilter.java
+++ b/src/main/java/org/example/bankramenserver/infrastructure/mcp/auth/McpBearerAuthenticationFilter.java
@@ -1,0 +1,59 @@
+package org.example.bankramenserver.infrastructure.mcp.auth;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.example.bankramenserver.global.error.exception.ErrorCode;
+import org.example.bankramenserver.global.error.exception.GlobalException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class McpBearerAuthenticationFilter extends OncePerRequestFilter {
+
+    private final McpAgentConnectionAuthenticationService authenticationService;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return !"/mcp".equals(request.getRequestURI());
+    }
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        McpAgentPrincipal principal = authenticationService.authenticate(resolveToken(request));
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                principal.scopes().stream()
+                        .map(scope -> new SimpleGrantedAuthority("SCOPE_" + scope.name()))
+                        .toList()
+        );
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String authorization = request.getHeader("Authorization");
+        if (!StringUtils.hasText(authorization) || !authorization.startsWith("Bearer ")) {
+            throw new GlobalException(ErrorCode.MISSING_TOKEN);
+        }
+        String token = authorization.substring(7);
+        if (!StringUtils.hasText(token)) {
+            throw new GlobalException(ErrorCode.MISSING_TOKEN);
+        }
+        return token;
+    }
+}

--- a/src/main/java/org/example/bankramenserver/infrastructure/mcp/auth/McpInitialConnectionInitializer.java
+++ b/src/main/java/org/example/bankramenserver/infrastructure/mcp/auth/McpInitialConnectionInitializer.java
@@ -1,0 +1,64 @@
+package org.example.bankramenserver.infrastructure.mcp.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.example.bankramenserver.domain.user.domain.repository.UserRepository;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.util.EnumSet;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class McpInitialConnectionInitializer implements ApplicationRunner {
+
+    private final McpInitialConnectionProperties properties;
+    private final AgentConnectionRepository agentConnectionRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public void run(ApplicationArguments args) {
+        if (!StringUtils.hasText(properties.getToken())) {
+            return;
+        }
+        if (properties.getToken().length() < 32) {
+            throw new IllegalStateException("MCP_INITIAL_TOKEN must contain at least 32 characters");
+        }
+        if (!StringUtils.hasText(properties.getConnectionId()) || !StringUtils.hasText(properties.getConsumerId())) {
+            throw new IllegalStateException("MCP_CONNECTION_ID and MCP_CONSUMER_ID are required when MCP_INITIAL_TOKEN is configured");
+        }
+        UUID linkedUserId = parseLinkedUserId();
+        if (!userRepository.existsById(linkedUserId)) {
+            throw new IllegalStateException("MCP_LINKED_USER_ID must identify an existing Bankramen user");
+        }
+        AgentConnection connection = agentConnectionRepository.findById(properties.getConnectionId())
+                .orElseGet(() -> AgentConnection.of(
+                        properties.getConnectionId(),
+                        properties.getConsumerId(),
+                        linkedUserId,
+                        properties.isEnabled(),
+                        McpTokenHasher.hash(properties.getToken()),
+                        EnumSet.of(AgentScope.TRANSACTIONS_READ, AgentScope.REPORTS_READ)
+                ));
+        connection.syncInitialConnection(
+                properties.getConsumerId(),
+                linkedUserId,
+                properties.isEnabled(),
+                McpTokenHasher.hash(properties.getToken())
+        );
+        agentConnectionRepository.save(connection);
+    }
+
+    private UUID parseLinkedUserId() {
+        if (!StringUtils.hasText(properties.getLinkedUserId())) {
+            throw new IllegalStateException("MCP_LINKED_USER_ID is required when MCP_INITIAL_TOKEN is configured");
+        }
+        try {
+            return UUID.fromString(properties.getLinkedUserId());
+        } catch (IllegalArgumentException exception) {
+            throw new IllegalStateException("MCP_LINKED_USER_ID must be a UUID when MCP_INITIAL_TOKEN is configured", exception);
+        }
+    }
+}

--- a/src/main/java/org/example/bankramenserver/infrastructure/mcp/auth/McpInitialConnectionProperties.java
+++ b/src/main/java/org/example/bankramenserver/infrastructure/mcp/auth/McpInitialConnectionProperties.java
@@ -1,0 +1,17 @@
+package org.example.bankramenserver.infrastructure.mcp.auth;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "mcp.initial-connection")
+public class McpInitialConnectionProperties {
+
+    private String connectionId;
+    private String consumerId;
+    private String linkedUserId;
+    private boolean enabled = true;
+    private String token;
+}

--- a/src/main/java/org/example/bankramenserver/infrastructure/mcp/auth/McpScopeDeniedException.java
+++ b/src/main/java/org/example/bankramenserver/infrastructure/mcp/auth/McpScopeDeniedException.java
@@ -1,0 +1,4 @@
+package org.example.bankramenserver.infrastructure.mcp.auth;
+
+public class McpScopeDeniedException extends RuntimeException {
+}

--- a/src/main/java/org/example/bankramenserver/infrastructure/mcp/auth/McpTokenHasher.java
+++ b/src/main/java/org/example/bankramenserver/infrastructure/mcp/auth/McpTokenHasher.java
@@ -1,0 +1,21 @@
+package org.example.bankramenserver.infrastructure.mcp.auth;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+public final class McpTokenHasher {
+
+    private McpTokenHasher() {
+    }
+
+    public static String hash(String token) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(token.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException exception) {
+            throw new IllegalStateException("SHA-256 is unavailable", exception);
+        }
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -65,3 +65,23 @@ gemini:
 fcm:
   enabled: ${FCM_ENABLED:false}
   credentials-path: ${FCM_CREDENTIALS_PATH:/config/bankramen.json}
+
+integration:
+  dispatch-interval-ms: ${INTEGRATION_DISPATCH_INTERVAL_MS:30000}
+  connections:
+    - connection-id: hermes-personal
+      consumer-id: yuseob-finance-assistant
+      connector-type: HERMES_WEBHOOK
+      enabled: ${HERMES_WEBHOOK_ENABLED:true}
+      subscribed-events:
+        - transaction.created
+      webhook-url: ${HERMES_WEBHOOK_URL:}
+      secret: ${HERMES_WEBHOOK_SECRET:}
+
+mcp:
+  initial-connection:
+    connection-id: ${MCP_CONNECTION_ID:hermes-local}
+    consumer-id: ${MCP_CONSUMER_ID:hermes-agent}
+    linked-user-id: ${MCP_LINKED_USER_ID:}
+    enabled: ${MCP_ENABLED:true}
+    token: ${MCP_INITIAL_TOKEN:}

--- a/src/test/java/org/example/bankramenserver/domain/push/event/PaymentTransactionRecordedEventListenerTest.java
+++ b/src/test/java/org/example/bankramenserver/domain/push/event/PaymentTransactionRecordedEventListenerTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.time.LocalDate;
 import java.util.Map;
 import java.util.UUID;
 
@@ -33,7 +34,8 @@ class PaymentTransactionRecordedEventListenerTest {
                 transactionId,
                 "스타벅스 강남점",
                 4500L,
-                Category.CAFE_SNACK
+                Category.CAFE_SNACK,
+                LocalDate.of(2026, 7, 11)
         ));
 
         verify(sendPushNotificationService).execute(

--- a/src/test/java/org/example/bankramenserver/infrastructure/integration/HermesWebhookConnectorTest.java
+++ b/src/test/java/org/example/bankramenserver/infrastructure/integration/HermesWebhookConnectorTest.java
@@ -1,0 +1,56 @@
+package org.example.bankramenserver.infrastructure.integration;
+
+import com.sun.net.httpserver.HttpServer;
+import org.example.bankramenserver.infrastructure.integration.domain.IntegrationConnectionProperties;
+import org.example.bankramenserver.infrastructure.integration.domain.IntegrationOutbox;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class HermesWebhookConnectorTest {
+
+    @Test
+    void sendsSignedPayloadAndIdempotencyHeaderToConfiguredConnection() throws Exception {
+        AtomicReference<String> body = new AtomicReference<>();
+        AtomicReference<String> signature = new AtomicReference<>();
+        AtomicReference<String> requestId = new AtomicReference<>();
+        HttpServer server = HttpServer.create(new InetSocketAddress(0), 0);
+        server.createContext("/hook", exchange -> {
+            body.set(new String(exchange.getRequestBody().readAllBytes(), StandardCharsets.UTF_8));
+            signature.set(exchange.getRequestHeaders().getFirst("X-Hub-Signature-256"));
+            requestId.set(exchange.getRequestHeaders().getFirst("X-Request-ID"));
+            exchange.sendResponseHeaders(202, -1);
+            exchange.close();
+        });
+        server.start();
+        try {
+            String payload = "{\"event_type\":\"transaction.created\"}";
+            IntegrationOutbox outbox = IntegrationOutbox.pending(
+                    "event-1", "hermes-personal", "HERMES_WEBHOOK", "transaction.created", payload
+            );
+            IntegrationConnectionProperties.Connection connection = new IntegrationConnectionProperties.Connection(
+                    "hermes-personal", "consumer", "HERMES_WEBHOOK", true, List.of("transaction.created"),
+                    "http://127.0.0.1:" + server.getAddress().getPort() + "/hook", "test-secret"
+            );
+
+            new HermesWebhookConnector().dispatch(outbox, connection);
+
+            assertThat(body.get()).isEqualTo(payload);
+            assertThat(signature.get()).isEqualTo(HermesWebhookConnector.signature(payload.getBytes(StandardCharsets.UTF_8), "test-secret"));
+            assertThat(requestId.get()).isEqualTo("event-1");
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
+    void signsTheExactUtf8PayloadBytesWithHmacSha256() {
+        assertThat(HermesWebhookConnector.signature("payload".getBytes(), "test-secret"))
+                .isEqualTo("sha256=2fcd0dbc44d5dd073ead5ea4b4d81cfd543e5de42e9c353f80452715e2b576a3");
+    }
+}

--- a/src/test/java/org/example/bankramenserver/infrastructure/integration/IntegrationOutboxDispatcherTest.java
+++ b/src/test/java/org/example/bankramenserver/infrastructure/integration/IntegrationOutboxDispatcherTest.java
@@ -1,0 +1,78 @@
+package org.example.bankramenserver.infrastructure.integration;
+
+import org.example.bankramenserver.infrastructure.integration.domain.IntegrationConnectionProperties;
+import org.example.bankramenserver.infrastructure.integration.domain.IntegrationOutbox;
+import org.example.bankramenserver.infrastructure.integration.domain.IntegrationOutboxRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class IntegrationOutboxDispatcherTest {
+
+    @Mock
+    private IntegrationOutboxRepository outboxRepository;
+
+    @Mock
+    private IntegrationConnector hermesConnector;
+
+    @Test
+    void dispatchesPendingEntryThroughItsConnectionAndMarksItDelivered() throws Exception {
+        IntegrationConnectionProperties properties = connections();
+        IntegrationOutbox outbox = IntegrationOutbox.pending(
+                "event-1", "hermes-personal", "HERMES_WEBHOOK", "transaction.created", "{\"event_type\":\"transaction.created\"}"
+        );
+        when(outboxRepository.findTop50ByStatusInOrderByCreatedAtAsc(List.of(
+                IntegrationOutbox.Status.PENDING, IntegrationOutbox.Status.RETRYING
+        ))).thenReturn(List.of(outbox));
+        when(hermesConnector.connectorType()).thenReturn("HERMES_WEBHOOK");
+        IntegrationOutboxDispatcher dispatcher = new IntegrationOutboxDispatcher(
+                outboxRepository, properties, List.of(hermesConnector)
+        );
+
+        dispatcher.dispatchDue();
+
+        verify(hermesConnector).dispatch(outbox, properties.getConnections().get(0));
+        assertThat(outbox.getStatus()).isEqualTo(IntegrationOutbox.Status.DELIVERED);
+    }
+
+    @Test
+    void keepsFailedDeliveryForRetryInsteadOfThrowing() throws Exception {
+        IntegrationConnectionProperties properties = connections();
+        IntegrationOutbox outbox = IntegrationOutbox.pending(
+                "event-1", "hermes-personal", "HERMES_WEBHOOK", "transaction.created", "{}"
+        );
+        when(outboxRepository.findTop50ByStatusInOrderByCreatedAtAsc(List.of(
+                IntegrationOutbox.Status.PENDING, IntegrationOutbox.Status.RETRYING
+        ))).thenReturn(List.of(outbox));
+        when(hermesConnector.connectorType()).thenReturn("HERMES_WEBHOOK");
+        org.mockito.Mockito.doThrow(new IllegalStateException("offline"))
+                .when(hermesConnector).dispatch(outbox, properties.getConnections().get(0));
+        IntegrationOutboxDispatcher dispatcher = new IntegrationOutboxDispatcher(
+                outboxRepository, properties, List.of(hermesConnector)
+        );
+
+        dispatcher.dispatchDue();
+
+        assertThat(outbox.getStatus()).isEqualTo(IntegrationOutbox.Status.RETRYING);
+        assertThat(outbox.getAttemptCount()).isEqualTo(1);
+        assertThat(outbox.getNextAttemptAt()).isAfter(LocalDateTime.now().minusSeconds(1));
+    }
+
+    private IntegrationConnectionProperties connections() {
+        IntegrationConnectionProperties properties = new IntegrationConnectionProperties();
+        properties.setConnections(List.of(new IntegrationConnectionProperties.Connection(
+                "hermes-personal", "yuseob-finance-assistant", "HERMES_WEBHOOK", true,
+                List.of("transaction.created"), "http://localhost:8644/webhooks/bankramen-transactions", "test-secret"
+        )));
+        return properties;
+    }
+}

--- a/src/test/java/org/example/bankramenserver/infrastructure/integration/IntegrationOutboxWriterTest.java
+++ b/src/test/java/org/example/bankramenserver/infrastructure/integration/IntegrationOutboxWriterTest.java
@@ -1,0 +1,60 @@
+package org.example.bankramenserver.infrastructure.integration;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.example.bankramenserver.domain.category.domain.Category;
+import org.example.bankramenserver.domain.transaction.event.PaymentTransactionRecordedEvent;
+import org.example.bankramenserver.infrastructure.integration.domain.IntegrationConnectionProperties;
+import org.example.bankramenserver.infrastructure.integration.domain.IntegrationOutbox;
+import org.example.bankramenserver.infrastructure.integration.domain.IntegrationOutboxRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class IntegrationOutboxWriterTest {
+
+    @Mock
+    private IntegrationOutboxRepository outboxRepository;
+
+    @Test
+    void recordsOnePendingDeliveryForEachEnabledSubscribedConnection() throws Exception {
+        IntegrationConnectionProperties properties = new IntegrationConnectionProperties();
+        properties.setConnections(List.of(
+                new IntegrationConnectionProperties.Connection(
+                        "hermes-personal", "yuseob-finance-assistant", "HERMES_WEBHOOK", true,
+                        List.of("transaction.created"), "http://localhost:8644/webhooks/bankramen-transactions", "test-secret"
+                ),
+                new IntegrationConnectionProperties.Connection(
+                        "disabled", "disabled-agent", "HERMES_WEBHOOK", false,
+                        List.of("transaction.created"), "http://localhost/disabled", "test-secret"
+                )
+        ));
+        IntegrationOutboxWriter writer = new IntegrationOutboxWriter(outboxRepository, properties, new ObjectMapper());
+        UUID userId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        UUID transactionId = UUID.fromString("22222222-2222-2222-2222-222222222222");
+
+        writer.record(new PaymentTransactionRecordedEvent(
+                userId, transactionId, "스타벅스", 4500L, Category.CAFE_SNACK, LocalDate.of(2026, 7, 11)
+        ));
+
+        ArgumentCaptor<IntegrationOutbox> captor = ArgumentCaptor.forClass(IntegrationOutbox.class);
+        verify(outboxRepository).save(captor.capture());
+        IntegrationOutbox outbox = captor.getValue();
+        JsonNode payload = new ObjectMapper().readTree(outbox.getPayload());
+        assertThat(outbox.getConnectionId()).isEqualTo("hermes-personal");
+        assertThat(outbox.getEventId()).isEqualTo(transactionId.toString());
+        assertThat(outbox.isPending()).isTrue();
+        assertThat(payload.path("event_type").asText()).isEqualTo("transaction.created");
+        assertThat(payload.path("transaction").path("amount").asLong()).isEqualTo(4500L);
+    }
+}

--- a/src/test/java/org/example/bankramenserver/infrastructure/mcp/McpFinancialToolsTest.java
+++ b/src/test/java/org/example/bankramenserver/infrastructure/mcp/McpFinancialToolsTest.java
@@ -1,0 +1,211 @@
+package org.example.bankramenserver.infrastructure.mcp;
+
+import org.example.bankramenserver.domain.category.domain.Category;
+import org.example.bankramenserver.domain.report.presentation.dto.MonthlyAmountSummaryResponse;
+import org.example.bankramenserver.domain.report.presentation.dto.MonthlyCategoryExpenseListResponse;
+import org.example.bankramenserver.domain.report.service.GetMonthlyAmountSummaryService;
+import org.example.bankramenserver.domain.report.service.GetMonthlyCategoryExpenseListService;
+import org.example.bankramenserver.domain.transaction.domain.Transaction;
+import org.example.bankramenserver.domain.transaction.presentation.dto.RecentTransactionListResponse;
+import org.example.bankramenserver.domain.transaction.presentation.dto.TransactionHistoryResponse;
+import org.example.bankramenserver.domain.transaction.service.GetRecentTransactionListService;
+import org.example.bankramenserver.infrastructure.mcp.auth.AgentScope;
+import org.example.bankramenserver.infrastructure.mcp.auth.McpAgentPrincipal;
+import org.example.bankramenserver.infrastructure.mcp.auth.McpAgentPrincipalResolver;
+import org.example.bankramenserver.infrastructure.mcp.auth.McpScopeDeniedException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class McpFinancialToolsTest {
+
+    private static final UUID LINKED_USER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+
+    @Mock
+    private McpAgentPrincipalResolver principalResolver;
+
+    @Mock
+    private GetRecentTransactionListService getRecentTransactionListService;
+
+    @Mock
+    private GetMonthlyAmountSummaryService getMonthlyAmountSummaryService;
+
+    @Mock
+    private GetMonthlyCategoryExpenseListService getMonthlyCategoryExpenseListService;
+
+    @InjectMocks
+    private McpFinancialTools tools;
+
+    @Test
+    void getRecentTransactionsUsesOnlyTheLinkedUser() {
+        when(principalResolver.requireScope(AgentScope.TRANSACTIONS_READ)).thenReturn(principal());
+        when(getRecentTransactionListService.execute(LINKED_USER_ID, 3)).thenReturn(
+                RecentTransactionListResponse.from(List.of(transaction()))
+        );
+
+        Map<String, Object> result = tools.getRecentTransactions(Map.of("limit", 3));
+
+        assertThat(result).containsEntry("transactions", List.of(Map.of(
+                "transactionId", "22222222-2222-2222-2222-222222222222",
+                "title", "Coffee",
+                "amount", 4500L,
+                "category", "FOOD",
+                "type", "EXPENSE",
+                "transactionDate", "2026-08-12"
+        )));
+        verify(getRecentTransactionListService).execute(LINKED_USER_ID, 3);
+    }
+
+    @Test
+    void getRecentTransactionsPreservesAMissingTitleAsNull() {
+        when(principalResolver.requireScope(AgentScope.TRANSACTIONS_READ)).thenReturn(principal());
+        when(getRecentTransactionListService.execute(LINKED_USER_ID, 1)).thenReturn(
+                RecentTransactionListResponse.from(List.of(transactionWithoutTitle()))
+        );
+
+        Map<String, Object> result = tools.getRecentTransactions(Map.of("limit", 1));
+
+        Map<?, ?> transaction = (Map<?, ?>) ((List<?>) result.get("transactions")).get(0);
+        assertThat(transaction.get("title")).isNull();
+    }
+
+    @Test
+    void getMonthlyExpenseSummaryDelegatesToTheMonthlyAmountReadPath() {
+        when(principalResolver.requireScope(AgentScope.REPORTS_READ)).thenReturn(principal());
+        when(getMonthlyAmountSummaryService.execute(LINKED_USER_ID, 2026, 8)).thenReturn(summary());
+
+        Map<String, Object> result = tools.getMonthlyExpenseSummary(Map.of("year", 2026, "month", 8));
+
+        assertThat(result).containsEntry("expense", Map.of(
+                "currentAmount", 4500L,
+                "previousAmount", 3000L,
+                "hasPreviousMonthData", true,
+                "differenceRate", BigDecimal.valueOf(50.0)
+        ));
+        verify(getMonthlyAmountSummaryService).execute(LINKED_USER_ID, 2026, 8);
+    }
+
+    @Test
+    void getCategoryExpensesDelegatesToTheCategoryExpenseReadPath() {
+        when(principalResolver.requireScope(AgentScope.REPORTS_READ)).thenReturn(principal());
+        when(getMonthlyCategoryExpenseListService.execute(LINKED_USER_ID, 2026, 8)).thenReturn(categories());
+
+        Map<String, Object> result = tools.getCategoryExpenses(Map.of("year", 2026, "month", 8));
+
+        assertThat(result).containsEntry("totalExpense", 4500L);
+        verify(getMonthlyCategoryExpenseListService).execute(LINKED_USER_ID, 2026, 8);
+    }
+
+    @Test
+    void getMonthlyIncomeExpenseSummaryDelegatesToTheMonthlyAmountReadPath() {
+        when(principalResolver.requireScope(AgentScope.REPORTS_READ)).thenReturn(principal());
+        when(getMonthlyAmountSummaryService.execute(LINKED_USER_ID, 2026, 8)).thenReturn(summary());
+
+        Map<String, Object> result = tools.getMonthlyIncomeExpenseSummary(Map.of("year", 2026, "month", 8));
+
+        assertThat(result).containsKeys("expense", "income", "yearMonth");
+        verify(getMonthlyAmountSummaryService).execute(LINKED_USER_ID, 2026, 8);
+    }
+
+    @Test
+    void rejectsInvalidArgumentsBeforeQueryingData() {
+        Map<String, Object> result = tools.getRecentTransactions(Map.of("limit", 0));
+
+        assertThat(result).containsEntry("error", "limit must be between 1 and 50");
+        verifyNoInteractions(principalResolver, getRecentTransactionListService,
+                getMonthlyAmountSummaryService, getMonthlyCategoryExpenseListService);
+    }
+
+    @Test
+    void rejectsAnInvalidMonthBeforeCheckingReportScope() {
+        Map<String, Object> result = tools.getCategoryExpenses(Map.of("year", 2026, "month", 13));
+
+        assertThat(result).containsEntry("error", "month must be between 1 and 12");
+        verifyNoInteractions(principalResolver, getRecentTransactionListService,
+                getMonthlyAmountSummaryService, getMonthlyCategoryExpenseListService);
+    }
+
+    @Test
+    void rejectsAnInvalidExpenseSummaryMonthBeforeCheckingReportScope() {
+        Map<String, Object> result = tools.getMonthlyExpenseSummary(Map.of("year", 2026, "month", 13));
+
+        assertThat(result).containsEntry("error", "month must be between 1 and 12");
+        verifyNoInteractions(principalResolver, getRecentTransactionListService,
+                getMonthlyAmountSummaryService, getMonthlyCategoryExpenseListService);
+    }
+
+    @Test
+    void rejectsAToolCallWithoutItsRequiredScope() {
+        when(principalResolver.requireScope(AgentScope.REPORTS_READ)).thenThrow(new McpScopeDeniedException());
+
+        Map<String, Object> result = tools.getCategoryExpenses(Map.of("year", 2026, "month", 8));
+
+        assertThat(result).containsEntry("error", "missing required MCP scope");
+        verifyNoInteractions(getMonthlyCategoryExpenseListService);
+    }
+
+    private McpAgentPrincipal principal() {
+        return new McpAgentPrincipal(
+                "hermes-local",
+                "hermes-agent",
+                LINKED_USER_ID,
+                Set.of(AgentScope.TRANSACTIONS_READ, AgentScope.REPORTS_READ)
+        );
+    }
+
+    private TransactionHistoryResponse transaction() {
+        return TransactionHistoryResponse.builder()
+                .transactionId(UUID.fromString("22222222-2222-2222-2222-222222222222"))
+                .title("Coffee")
+                .amount(4500L)
+                .category(Category.FOOD)
+                .type(Transaction.TransactionType.EXPENSE)
+                .transactionDate(LocalDate.of(2026, 8, 12))
+                .build();
+    }
+
+    private TransactionHistoryResponse transactionWithoutTitle() {
+        return TransactionHistoryResponse.builder()
+                .transactionId(UUID.fromString("22222222-2222-2222-2222-222222222222"))
+                .title(null)
+                .amount(4500L)
+                .category(Category.FOOD)
+                .type(Transaction.TransactionType.EXPENSE)
+                .transactionDate(LocalDate.of(2026, 8, 12))
+                .build();
+    }
+
+    private MonthlyAmountSummaryResponse summary() {
+        return MonthlyAmountSummaryResponse.of(
+                YearMonth.of(2026, 8),
+                MonthlyAmountSummaryResponse.AmountComparison.of(4500L, 3000L, BigDecimal.valueOf(50.0)),
+                MonthlyAmountSummaryResponse.AmountComparison.of(10000L, 9000L, BigDecimal.valueOf(11.1))
+        );
+    }
+
+    private MonthlyCategoryExpenseListResponse categories() {
+        return MonthlyCategoryExpenseListResponse.of(
+                YearMonth.of(2026, 8),
+                4500L,
+                List.of(MonthlyCategoryExpenseListResponse.CategoryExpense.of(
+                        Category.FOOD, "Food", 4500L, BigDecimal.valueOf(100.0), true
+                ))
+        );
+    }
+}

--- a/src/test/java/org/example/bankramenserver/infrastructure/mcp/McpTransportIntegrationTest.java
+++ b/src/test/java/org/example/bankramenserver/infrastructure/mcp/McpTransportIntegrationTest.java
@@ -1,0 +1,90 @@
+package org.example.bankramenserver.infrastructure.mcp;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.modelcontextprotocol.server.transport.HttpServletStreamableServerTransportProvider;
+import org.apache.catalina.Context;
+import org.apache.catalina.startup.Tomcat;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.stream.StreamSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class McpTransportIntegrationTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+
+    @Test
+    void streamableHttpEndpointDiscoversTheFourReadOnlyTools() throws Exception {
+        McpServerConfiguration configuration = new McpServerConfiguration(mock(McpFinancialTools.class), objectMapper);
+        HttpServletStreamableServerTransportProvider transport = configuration.mcpTransport();
+        configuration.mcpServer(transport);
+        Tomcat tomcat = new Tomcat();
+        tomcat.setBaseDir(Files.createTempDirectory("mcp-transport-test").toString());
+        tomcat.setPort(0);
+        Context context = tomcat.addContext("", null);
+        Tomcat.addServlet(context, "mcp", transport);
+        context.addServletMappingDecoded("/mcp", "mcp");
+        tomcat.start();
+        try {
+            HttpResponse<String> initializeResponse = call(tomcat.getConnector().getLocalPort(), """
+                {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test-client","version":"1.0"}}}
+                """, null);
+            String sessionId = initializeResponse.headers().firstValue("Mcp-Session-Id").orElse(null);
+
+            HttpResponse<String> toolsResponse = call(tomcat.getConnector().getLocalPort(), """
+                {"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
+                """, sessionId);
+            JsonNode tools = responseBody(toolsResponse.body()).path("result").path("tools");
+
+            assertThat(initializeResponse.statusCode()).as(initializeResponse.body()).isEqualTo(200);
+            assertThat(sessionId).isNotBlank();
+            assertThat(toolsResponse.statusCode()).isEqualTo(200);
+            assertThat(tools).extracting(node -> node.path("name").asText()).containsExactlyInAnyOrder(
+                    "get_recent_transactions",
+                    "get_monthly_expense_summary",
+                    "get_category_expenses",
+                    "get_monthly_income_expense_summary"
+            );
+            JsonNode monthlyExpenseSummary = StreamSupport.stream(tools.spliterator(), false)
+                    .filter(tool -> "get_monthly_expense_summary".equals(tool.path("name").asText()))
+                    .findFirst()
+                    .orElseThrow();
+            assertThat(monthlyExpenseSummary
+                    .path("inputSchema").path("properties").path("year").path("maximum").asInt())
+                    .isEqualTo(2100);
+        } finally {
+            tomcat.stop();
+            tomcat.destroy();
+        }
+    }
+
+    private HttpResponse<String> call(int port, String body, String sessionId) throws Exception {
+        HttpRequest.Builder request = HttpRequest.newBuilder(URI.create("http://localhost:" + port + "/mcp"))
+                .header("Content-Type", "application/json")
+                .header("Accept", "application/json, text/event-stream")
+                .POST(HttpRequest.BodyPublishers.ofString(body));
+        if (sessionId != null) {
+            request.header("Mcp-Session-Id", sessionId);
+        }
+        return httpClient.send(request.build(), HttpResponse.BodyHandlers.ofString());
+    }
+
+    private JsonNode responseBody(String body) throws Exception {
+        String json = body.lines()
+                .filter(line -> line.startsWith("data: "))
+                .map(line -> line.substring(6))
+                .findFirst()
+                .orElse(body);
+        return objectMapper.readTree(json);
+    }
+
+}

--- a/src/test/java/org/example/bankramenserver/infrastructure/mcp/auth/McpAgentConnectionAuthenticationServiceTest.java
+++ b/src/test/java/org/example/bankramenserver/infrastructure/mcp/auth/McpAgentConnectionAuthenticationServiceTest.java
@@ -1,0 +1,104 @@
+package org.example.bankramenserver.infrastructure.mcp.auth;
+
+import org.example.bankramenserver.domain.user.domain.repository.UserRepository;
+import org.example.bankramenserver.global.error.exception.GlobalException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.example.bankramenserver.global.error.exception.ErrorCode.INVALID_TOKEN;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class McpAgentConnectionAuthenticationServiceTest {
+
+    private static final UUID LINKED_USER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+
+    @Mock
+    private AgentConnectionRepository agentConnectionRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private McpAgentConnectionAuthenticationService authenticationService;
+
+    @Test
+    void authenticatesAnEnabledConnectionToItsLinkedUser() {
+        // Given
+        AgentConnection connection = AgentConnection.of(
+                "hermes-local",
+                "hermes-agent",
+                LINKED_USER_ID,
+                true,
+                McpTokenHasher.hash("local-agent-token"),
+                Set.of(AgentScope.TRANSACTIONS_READ, AgentScope.REPORTS_READ)
+        );
+        when(agentConnectionRepository.findByTokenHash(McpTokenHasher.hash("local-agent-token")))
+                .thenReturn(java.util.Optional.of(connection));
+        when(userRepository.existsById(LINKED_USER_ID)).thenReturn(true);
+
+        // When
+        McpAgentPrincipal principal = authenticationService.authenticate("local-agent-token");
+
+        // Then
+        assertThat(principal.linkedUserId()).isEqualTo(LINKED_USER_ID);
+        assertThat(principal.scopes()).containsExactlyInAnyOrder(
+                AgentScope.TRANSACTIONS_READ,
+                AgentScope.REPORTS_READ
+        );
+    }
+
+    @Test
+    void rejectsUnknownOrDisabledConnections() {
+        // Given
+        when(agentConnectionRepository.findByTokenHash(anyString())).thenReturn(java.util.Optional.empty());
+        when(agentConnectionRepository.findByTokenHash(McpTokenHasher.hash("disabled-token")))
+                .thenReturn(java.util.Optional.of(AgentConnection.of(
+                        "hermes-disabled",
+                        "hermes-agent",
+                        LINKED_USER_ID,
+                        false,
+                        McpTokenHasher.hash("disabled-token"),
+                        Set.of(AgentScope.TRANSACTIONS_READ)
+                )));
+
+        // When / Then
+        assertThatThrownBy(() -> authenticationService.authenticate("unknown-token"))
+                .isInstanceOf(GlobalException.class)
+                .extracting(error -> ((GlobalException) error).getErrorCode())
+                .isEqualTo(INVALID_TOKEN);
+
+        assertThatThrownBy(() -> authenticationService.authenticate("disabled-token"))
+                .isInstanceOf(GlobalException.class)
+                .extracting(error -> ((GlobalException) error).getErrorCode())
+                .isEqualTo(INVALID_TOKEN);
+    }
+
+    @Test
+    void rejectsAConnectionWhoseLinkedUserIsMissing() {
+        when(agentConnectionRepository.findByTokenHash(McpTokenHasher.hash("orphan-token")))
+                .thenReturn(java.util.Optional.of(AgentConnection.of(
+                        "hermes-orphan",
+                        "hermes-agent",
+                        LINKED_USER_ID,
+                        true,
+                        McpTokenHasher.hash("orphan-token"),
+                        Set.of(AgentScope.REPORTS_READ)
+                )));
+        when(userRepository.existsById(LINKED_USER_ID)).thenReturn(false);
+
+        assertThatThrownBy(() -> authenticationService.authenticate("orphan-token"))
+                .isInstanceOf(GlobalException.class)
+                .extracting(error -> ((GlobalException) error).getErrorCode())
+                .isEqualTo(INVALID_TOKEN);
+    }
+}

--- a/src/test/java/org/example/bankramenserver/infrastructure/mcp/auth/McpInitialConnectionInitializerTest.java
+++ b/src/test/java/org/example/bankramenserver/infrastructure/mcp/auth/McpInitialConnectionInitializerTest.java
@@ -1,0 +1,74 @@
+package org.example.bankramenserver.infrastructure.mcp.auth;
+
+import org.example.bankramenserver.domain.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.DefaultApplicationArguments;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class McpInitialConnectionInitializerTest {
+
+    private static final UUID LINKED_USER_ID = UUID.fromString("11111111-1111-1111-1111-111111111111");
+
+    @Mock
+    private AgentConnectionRepository agentConnectionRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private McpInitialConnectionInitializer initializer;
+
+    @Test
+    void updatesAnExistingConfiguredConnectionOnStartup() throws Exception {
+        McpInitialConnectionProperties properties = new McpInitialConnectionProperties();
+        properties.setConnectionId("hermes-local");
+        properties.setConsumerId("hermes-agent");
+        properties.setLinkedUserId(LINKED_USER_ID.toString());
+        properties.setEnabled(false);
+        properties.setToken("rotated-token-12345678901234567890");
+        AgentConnection connection = AgentConnection.of(
+                "hermes-local",
+                "hermes-agent",
+                LINKED_USER_ID,
+                true,
+                McpTokenHasher.hash("old-token"),
+                Set.of(AgentScope.TRANSACTIONS_READ)
+        );
+        initializer = new McpInitialConnectionInitializer(properties, agentConnectionRepository, userRepository);
+        when(agentConnectionRepository.findById("hermes-local")).thenReturn(Optional.of(connection));
+        when(userRepository.existsById(LINKED_USER_ID)).thenReturn(true);
+
+        initializer.run(new DefaultApplicationArguments());
+
+        assertThat(connection.isEnabled()).isFalse();
+        assertThat(connection.getTokenHash()).isEqualTo(McpTokenHasher.hash("rotated-token-12345678901234567890"));
+        assertThat(connection.getScopes()).containsExactlyInAnyOrder(
+                AgentScope.TRANSACTIONS_READ,
+                AgentScope.REPORTS_READ
+        );
+    }
+
+    @Test
+    void rejectsAnInitialTokenThatIsTooShort() {
+        McpInitialConnectionProperties properties = new McpInitialConnectionProperties();
+        properties.setConnectionId("hermes-local");
+        properties.setConsumerId("hermes-agent");
+        properties.setLinkedUserId(LINKED_USER_ID.toString());
+        properties.setToken("too-short");
+        initializer = new McpInitialConnectionInitializer(properties, agentConnectionRepository, userRepository);
+
+        assertThatThrownBy(() -> initializer.run(new DefaultApplicationArguments()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("MCP_INITIAL_TOKEN must contain at least 32 characters");
+    }
+}


### PR DESCRIPTION
## Summary
- MCP 금융 조회 도구와 에이전트 연결·스코프 기반 인증을 추가했습니다.
- 결제 거래 이벤트를 Hermes 웹훅으로 전달하는 Outbox 저장·재시도·스케줄러를 추가했습니다.
- 최근 거래 및 월간 리포트 조회를 MCP 호출에 맞게 확장하고, FCM 응답 처리를 보완했습니다.
- 연동 설정과 `.env.example`, MCP·Outbox·인증 테스트를 추가했습니다.

## Security / Configuration
- MCP는 연결된 에이전트 토큰과 명시적 스코프로 접근을 제한합니다.
- `application.yaml` 및 `.env.example`의 MCP/Hermes 연동 환경 변수를 설정해야 합니다.

## Verification
- `bash ./gradlew test --rerun-tasks`
- `git diff --check`

Closes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * MCP를 통해 최근 거래, 월별 지출, 카테고리별 지출, 수입·지출 비교 정보를 조회할 수 있습니다.
  * MCP 연결 인증과 거래·보고서 조회 권한 검증을 지원합니다.
  * 거래 기록 이벤트를 Hermes 웹훅으로 안전하게 전송하고, 실패 시 자동 재시도합니다.
* **개선 사항**
  * 월별 보고서와 최근 거래 조회가 지정된 사용자 기준으로 처리됩니다.
  * 거래 이벤트에 거래일 정보가 포함됩니다.
* **테스트**
  * MCP 도구, 인증, 웹훅 전송 및 재시도 동작을 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->